### PR TITLE
Fixes previous steps not loading when stack background is true

### DIFF
--- a/src/components/Scroller/Background.svelte
+++ b/src/components/Scroller/Background.svelte
@@ -9,7 +9,8 @@
 
 {#each steps as step, i}
   <!-- Load the step(s) before and after the active one, only -->
-  {#if preload === 0 || (i >= index - preload && i <= index + preload)}
+  <!-- Unless stackBackground is true. If so, keep all steps before the current one loaded. -->
+  {#if preload === 0 || (i >= (stackBackground ? 0 : index - preload) && i <= index + preload)}
     <div
       class="step-background step-{i + 1}"
       class:visible="{stackBackground ? i <= index : i === index}"


### PR DESCRIPTION
Thanks to @pmagtulis for finding this bug.

stackBackground wasn't loading all previous steps because of preload.

Fixed by adding stackBackground check inside the preload math.

### What's in this pull request

- [x ] Bug fix
- [ ] New component/feature
- [ ] Documentation update
- [ ] Other

### Description

Tell us what this PR does or link to any related issues that describe the goal here.

### Before submitting, please check that you've

- [ ] Read our [contributing guide](https://github.com/reuters-graphics/graphics-components/blob/master/CONTRIBUTING.md) at some point
- [ ] Formatted you code correctly (i.e., prettier cleaned it up)
- [ ] Documented any new components or features
- [ ] Tagged an editor to review
