### PR TITLE
Fix prop name in video, SCSS docs

### DIFF
--- a/src/components/Video/docs.svx
+++ b/src/components/Video/docs.svx
@@ -26,7 +26,7 @@ slug: video
 <Video
   ariaDescription={"Compulsory description of your video for screen readers."}
   src={`${assets}/videos/myVideo.mp4`} // or a URL to an external video
-  size={'wide'} // normal, wide, wider, widest or fluid
+  width={'wide'} // normal, wide, wider, widest or fluid
   caption={'Optional caption for your video.'}
 />
 ```
@@ -35,7 +35,7 @@ slug: video
   <Video
     ariaDescription="Description of your video for screen readers."
     src={`${assets}/videos/Sequence silent video_4.mp4`}
-    size="wide"
+    width="wide"
     caption="World's longest glass bridge opens to public in Vietnam. (c) 2022 Thomson Reuters"
   />
 </DemoContainer>
@@ -69,7 +69,7 @@ Here is an example of what the same video would look like with a visibility thre
 <Video
   ariaDescription="{'Compulsory description of your video for screen readers.'}"
   src="{'path-to-video-or-external-url'}"
-  size="{'normal'}"
+  width="{'normal'}"
   loopVideo="{false}"
   playVideoThreshold="{0.9}"
 />
@@ -79,7 +79,7 @@ Here is an example of what the same video would look like with a visibility thre
   <Video
     ariaDescription="Description of your video for screen readers."
     src={`${assets}/videos/Sequence silent video_4.mp4`}
-    size="normal"
+    width="normal"
     caption="World's longest glass bridge opens to public in Vietnam. (c) 2022 Thomson Reuters"
     loopVideo={false}
     playVideoThreshold={0.9}
@@ -182,7 +182,7 @@ and go to the top. Click anywhere on the page before scrolling down to the video
 <Video
   ariaDescription="{'Compulsory description of your video for screen readers.'}"
   src="{'path-to-video-or-external-url'}"
-  size="{'normal'}"
+  width="{'normal'}"
   controlsOpacity="{1}"
   loopVideo="{false}"
   muteVideo="{false}"
@@ -194,7 +194,7 @@ and go to the top. Click anywhere on the page before scrolling down to the video
   <Video
     ariaDescription="Description of your video for screen readers."
     src={`${assets}/videos/Sequence sound video.mp4`}
-    size="normal"
+    width="normal"
     caption="World's longest glass bridge opens to public in Vietnam. (c) 2022 Thomson Reuters"
     controlsOpacity={1}
     loopVideo={false}

--- a/src/docs/scss/fonts.stories.mdx
+++ b/src/docs/scss/fonts.stories.mdx
@@ -24,7 +24,7 @@ There are several ways to specify font styles.
 ```svelte
 <style lang="scss">
   // Import SCSS variables
-  @import 'reuters-graphics/graphics-components/dist/scss/variables';
+  @import '@reuters-graphics/graphics-components/dist/scss/variables';
 
   p {
     // Use one...
@@ -41,7 +41,7 @@ There are several ways to specify font styles.
 ```svelte
 <style lang="scss">
   // Import SCSS mixins
-  @import 'reuters-graphics/graphics-components/dist/scss/mixins';
+  @import '@reuters-graphics/graphics-components/dist/scss/mixins';
 
   p {
     // Use one...

--- a/src/docs/scss/mixins.stories.mdx
+++ b/src/docs/scss/mixins.stories.mdx
@@ -25,7 +25,7 @@ Mixin our default body text styles.
 
 <style lang="scss">
   // Import SCSS mixins
-  @import 'reuters-graphics/graphics-components/dist/scss/mixins';
+  @import '@reuters-graphics/graphics-components/dist/scss/mixins';
 
   div.my-custom-text {
     // Use body-text rules for all text elements
@@ -50,7 +50,7 @@ Graphic text styles.
 </div>
 
 <style lang="scss">
-  @import 'reuters-graphics/graphics-components/dist/scss/mixins';
+  @import '@reuters-graphics/graphics-components/dist/scss/mixins';
 
   div.my-chart-container {
     @include graphic-text;
@@ -68,7 +68,7 @@ Hide text meant for screen readers.
 </div>
 
 <style lang="scss">
-  @import 'reuters-graphics/graphics-components/dist/scss/mixins';
+  @import '@reuters-graphics/graphics-components/dist/scss/mixins';
 
   div.hidden {
     @include visually-hidden;


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix
- [ ] New component/feature
- [ ] Documentation update
- [ ] Other

### Description
Sometimes the prop names in the copy-paste section of the docs are wrong. A quick fix to correct prop names.

See https://github.com/reuters-graphics/graphics-components/issues/48