### PR TITLE
added video option for the photo pack

### DIFF
--- a/src/components/PhotoPack/PhotoPack.stories.svelte
+++ b/src/components/PhotoPack/PhotoPack.stories.svelte
@@ -7,11 +7,16 @@
   import quickitDocs from './stories/docs/quickit.md?raw';
   // @ts-ignore
   import missingAltTextDocs from './stories/docs/missingAltText.md?raw';
+  // @ts-ignore
+  import imagesAndVideosDocs from './stories/docs/imagesAndVideos.md?raw';
 
   import PhotoPack from './PhotoPack.svelte';
   import { getPhotoPackPropsFromDoc } from './docProps';
 
   import { withComponentDocs, withStoryDocs } from '$docs/utils/withParams.js';
+
+  // @ts-ignore
+  import SilentVideo from './stories/videos/silent-video.mp4';
 
   const meta = {
     title: 'Components/PhotoPack',
@@ -31,6 +36,7 @@
 
   const defaultImages = [
     {
+      type: 'image',
       src: 'https://via.placeholder.com/1024x768.jpg',
       altText: 'alt text',
       caption:
@@ -38,18 +44,21 @@
       maxHeight: 400,
     },
     {
+      type: 'image',
       src: 'https://via.placeholder.com/1640x1180.jpg',
       altText: 'alt text',
       caption:
         'Surveillance footage shows a missile hitting a residential building in Kyiv, Ukraine, February 26, 2022, in this still image taken from a video obtained by REUTERS',
     },
     {
+      type: 'image',
       src: 'https://via.placeholder.com/1200x900.jpg',
       altText: 'alt text',
       caption:
         'People walk past the remains of a missile at a bus terminal in Kyiv, Ukraine March 4, 2022. REUTERS/Valentyn Ogirenko',
     },
     {
+      type: 'image',
       src: 'https://via.placeholder.com/1024x768.jpg',
       altText: 'alt text',
       caption:
@@ -71,27 +80,32 @@
     Gap: '10',
     Images: [
       {
+        Type: 'image',
         Src: 'https://via.placeholder.com/1024x768.jpg',
         AltText: 'alt text',
         Caption: 'Lorem ipsum. Reuters/Photog',
         MaxHeight: '600',
       },
       {
+        Type: 'image',
         Src: 'https://via.placeholder.com/1024x768.jpg',
         AltText: 'alt text',
         Caption: 'Lorem ipsum. Reuters/Photog',
       },
       {
+        Type: 'image',
         Src: 'https://via.placeholder.com/1024x768.jpg',
         AltText: 'alt text',
         Caption: 'Lorem ipsum. Reuters/Photog',
       },
       {
+        Type: 'image',
         Src: 'https://via.placeholder.com/1024x768.jpg',
         AltText: 'alt text',
         Caption: 'Lorem ipsum. Reuters/Photog',
       },
       {
+        Type: 'image',
         Src: 'https://via.placeholder.com/1024x768.jpg',
         AltText: 'alt text',
         Caption: 'Lorem ipsum. Reuters/Photog',
@@ -105,6 +119,7 @@
 
   const altTextImages = [
     {
+      type: 'image',
       src: 'https://via.placeholder.com/1024x768.jpg',
       altText: 'alt text',
       caption:
@@ -112,6 +127,7 @@
       maxHeight: 400,
     },
     {
+      type: 'image',
       src: 'https://via.placeholder.com/1640x1180.jpg',
       altText: '',
       caption:
@@ -119,6 +135,52 @@
     },
   ];
   const altTextLayouts = [{ breakpoint: 450, rows: [2] }];
+
+  const imagesAndVideosBlock = {
+    Type: 'photo-pack',
+    ID: 'my-photo-pack',
+    Class: 'mb-2',
+    Width: 'wide',
+    CaptionWidth: 'normal',
+    Gap: '10',
+    Images: [
+      {
+        Type: 'video',
+        Src: SilentVideo,
+        AltText: 'Alt text for the video',
+        Caption: 'Caption for the video. Reuters/Photog',
+        MaxHeight: '600',
+      },
+      {
+        Type: 'image',
+        Src: 'https://via.placeholder.com/1024x768.jpg',
+        AltText: 'alt text',
+        Caption: 'Caption for image #1. Reuters/Photog',
+      },
+      {
+        Type: 'image',
+        Src: 'https://via.placeholder.com/1024x768.jpg',
+        AltText: 'alt text',
+        Caption: 'Caption for image #2. Reuters/Photog',
+      },
+      {
+        Type: 'image',
+        Src: 'https://via.placeholder.com/1024x768.jpg',
+        AltText: 'alt text',
+        Caption: 'Caption for image #3. Reuters/Photog',
+      },
+      {
+        Type: 'image',
+        Src: 'https://via.placeholder.com/1024x768.jpg',
+        AltText: 'alt text',
+        Caption: 'Caption for image #4. Reuters/Photog',
+      },
+    ],
+    Layouts: [
+      { Breakpoint: '750', Rows: '2,3' },
+      { Breakpoint: '450', Rows: '1, 2, 2' },
+    ],
+  };
 </script>
 
 <Meta {...meta} />
@@ -152,4 +214,10 @@
     layouts: altTextLayouts,
   }}"
   {...withStoryDocs(missingAltTextDocs)}
+/>
+
+<Story
+  name="Mix of images and videos"
+  {...withStoryDocs(imagesAndVideosDocs)}
+  args="{getPhotoPackPropsFromDoc(imagesAndVideosBlock)}"
 />

--- a/src/components/PhotoPack/PhotoPack.svelte
+++ b/src/components/PhotoPack/PhotoPack.svelte
@@ -1,6 +1,7 @@
 <!-- @component `PhotoPack` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-PhotoPack--default) -->
 <script lang="ts">
   interface Image {
+    type?: 'image' | 'video';
     src: string;
     altText: string;
     caption?: string;
@@ -98,11 +99,27 @@
       >
         {#each row as img, i}
           <figure aria-labelledby="{id}-figure-{ri}-{i}">
-            <img
-              src="{img.src}"
-              alt="{img.altText}"
-              style:max-height="{img.maxHeight ? img.maxHeight + 'px' : ''}"
-            />
+            {#if img.type === 'video'}
+              <video
+                class="media"
+                muted="{true}"
+                autoplay="{true}"
+                loop="{true}"
+                playsinline
+                src="{img.src}"
+                style:max-height="{img.maxHeight ? img.maxHeight + 'px' : ''}"
+              ></video>
+              <div class="visually-hidden">
+                <p>{img.altText}</p>
+              </div>
+            {:else}
+              <img
+                class="media"
+                src="{img.src}"
+                alt="{img.altText}"
+                style:max-height="{img.maxHeight ? img.maxHeight + 'px' : ''}"
+              />
+            {/if}
             {#if !img.altText}
               <div class="alt-warning">altText</div>
             {/if}
@@ -131,6 +148,11 @@
 <style lang="scss">
   @import '../../scss/fonts/variables';
   @import '../../scss/colours/thematic/tr';
+  @import '../../scss/mixins';
+
+  div.visually-hidden {
+    @include visually-hidden;
+  }
 
   div.photopack-container {
     display: block;
@@ -144,7 +166,7 @@
         margin: 0;
         padding: 0;
         position: relative;
-        img {
+        .media {
           margin: 0;
           width: 100%;
           height: 100%;

--- a/src/components/PhotoPack/docProps.ts
+++ b/src/components/PhotoPack/docProps.ts
@@ -1,6 +1,7 @@
 import urlJoin from 'proper-url-join';
 
 interface BlockImage {
+  Type: string,
   Src: string;
   AltText: string;
   Caption?: string;
@@ -31,6 +32,7 @@ export const getPhotoPackPropsFromDoc = (docBlock: Block, assetsPath: string = '
     captionWidth: docBlock.CaptionWidth,
     gap: docBlock.Gap && isNaN(docBlock.Gap as any) ? null : parseInt(docBlock.Gap),
     images: docBlock.Images.map((img) => ({
+      type: img.Type,
       src: /^https?:\/\/|^\/\//i.test(img.Src) ? img.Src : urlJoin(assetsPath, img.Src),
       altText: img.AltText,
       caption: img.Caption,

--- a/src/components/PhotoPack/stories/docs/imagesAndVideos.md
+++ b/src/components/PhotoPack/stories/docs/imagesAndVideos.md
@@ -1,0 +1,3 @@
+In addition to images, you can also add videos. These are intentionally simple - they will autoplay, loop and don't support sound.
+The way you provide a video is the same as with images, i.e. just give it an `src`, `altText` and `caption` as you would for an image.
+The only other thing you need to add is a `type: 'video'`.


### PR DESCRIPTION
### What's in this pull request
Added the option to include videos instead of photos in the PhotoPack component. 

It's a simple option by design (but happy to accept requests otherwise) - videos will be muted and looped. 

I intentionally left the name of the prop as `images` in order to preserve the existing component functionality. However, I'd consider renaming it to, say, `media` instead. The way to signify that a video is being passed in rather than an image is through an optional prop called `type`, which needs to be set to `video` for a video. 
