### PR TITLE
Add the Trust Principles as a default item in our NoteText

### DIFF
--- a/src/components/NoteText/NoteText.svelte
+++ b/src/components/NoteText/NoteText.svelte
@@ -7,6 +7,12 @@
    */
   export let text: string;
 
+  /**
+   * Whether or not to include our Trust Principles at the bottom of the note. True by default.
+   * @type {boolean}
+   */
+  export let trustPrinciples: boolean = true;
+
   import { marked } from 'marked';
   import Block from '../Block/Block.svelte';
 </script>
@@ -14,6 +20,16 @@
 <Block cls="notes mb-6">
   {#if text}
     {@html marked.parse(text)}
+  {/if}
+  {#if trustPrinciples}
+    <h3>Standards</h3>
+    <p>
+      Thomson Reuters is dedicated to upholding the Trust Principles. Learn more
+      by reading <a
+        href="https://www.thomsonreuters.com/en/about-us/trust-principles.html"
+        >our commitment</a
+      > to independence, integrity and freedom from bias.
+    </p>
   {/if}
 </Block>
 


### PR DESCRIPTION
This patch would add the trust principles to our standard note. It could be removed by setting a new variable to false. This feature is standard on all of our stories published via Arc, so I figure it would be nice to include here. 
![Screen Shot 2023-04-14 at 10 04 15 AM](https://user-images.githubusercontent.com/9993/232110433-4bdef553-688c-4374-ba34-6558ba9ec4c1.png)
