### PR TITLE
Add .devcontainer configuration for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "name": "Node.js",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:0-16",
+    "postCreateCommand": "yarn install",
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
     "name": "Node.js",
     "image": "mcr.microsoft.com/devcontainers/javascript-node:0-16",
-    "postCreateCommand": "yarn install",
+    "postCreateCommand": "yarn install"
 }


### PR DESCRIPTION
This aims to allow GitHub Codespaces to quickly spin up a working instance of this repository.