### PR TITLE
Make <h1> tag's font-size setting responsive in Headline component

### DIFF
--- a/src/components/Headline/Headline.svelte
+++ b/src/components/Headline/Headline.svelte
@@ -80,11 +80,33 @@
 
     :global {
       h1 {
-        font-size: 4rem;
         margin: 5px 0;
         line-height: 1.1;
         font-family: var(--theme-font-family-hed, $font-family-display);
         color: var(--theme-colour-text-primary, $tr-dark-grey);
+
+        // The default font-size for x-small devices (portrait phones, less than 576px)
+        font-size: 2.5rem;
+
+        // Small devices (landscape phones, 576px and up)
+        @media (min-width: 576px) {
+          font-size: 2.75rem;
+        }
+
+        // Medium devices (tablets, 768px and up)
+        @media (min-width: 768px) {
+          font-size: 3rem;
+        }
+
+        // Large devices (desktops, 992px and up)
+        @media (min-width: 992px) {
+          font-size: 3.5rem;
+        }
+
+        // X-Large devices (large desktops, 1200px and up)
+        @media (min-width: 1200px) {
+          font-size: 4rem;
+        }
       }
 
       p {


### PR DESCRIPTION
One of our editors alerted me to a small wrinkle in the Headline component: The font-size for h1 tags isn't responsive. This patch attempts to address the issue by scaling the size down for smaller devices.