### PR TITLE
Break out Select from Table as its own Component

### DIFF
--- a/src/components/Select/Select.stories.svelte
+++ b/src/components/Select/Select.stories.svelte
@@ -1,0 +1,65 @@
+<script>
+  import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+
+  // Don't lose the "?raw" in markdown imports!
+  // @ts-ignore
+  import componentDocs from './stories/docs/component.md?raw';
+  // @ts-ignore
+  import labelDocs from './stories/docs/label.md?raw';
+  // @ts-ignore
+  import defaultDocs from './stories/docs/default.md?raw';
+
+  import Select from './Select.svelte';
+
+  import { withComponentDocs, withStoryDocs } from '$docs/utils/withParams.js';
+
+  const optionList = [
+    {
+      text: 'Red',
+      value: 'r',
+    },
+    {
+      text: 'Blue',
+      value: 'b',
+    },
+    {
+      text: 'Green',
+      value: 'g',
+    },
+  ];
+
+  const metaProps = {
+    ...withComponentDocs(componentDocs),
+  };
+</script>
+
+<Meta title="Components/Select" component="{Select}" {...metaProps} />
+
+<Template let:args>
+  <Select {...args} />
+</Template>
+
+<Story
+  name="Default"
+  args="{{
+    options: optionList,
+  }}"
+/>
+
+<Story
+  name="Label"
+  {...withStoryDocs(labelDocs)}
+  args="{{
+    label: 'Pick a color',
+    options: optionList,
+  }}"
+/>
+
+<Story
+  name="Selected"
+  {...withStoryDocs(defaultDocs)}
+  args="{{
+    selected: 'g',
+    options: optionList,
+  }}"
+/>

--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -1,7 +1,7 @@
 <!-- @component `Select` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-Select--default) -->
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import type { Option } from '@reuters-graphics/graphics-components/dist/components/@types/global';
+  import type { Option } from '../@types/global';
 
   /**
    * The label that appears above the select input.

--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -1,6 +1,7 @@
+<!-- @component `Select` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-Select--default) -->
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import type { Option } from '../@types/global';
+  import type { Option } from '@reuters-graphics/graphics-components/dist/components/@types/global';
 
   /**
    * The label that appears above the select input.
@@ -14,23 +15,44 @@
    */
   export let options: Option[] = [];
 
+  /**
+   * The selected value
+   * @type {string}
+   */
+  export let selected: string | null = null;
+
+  /** Add an ID to target with SCSS.
+   * @type {string}
+   */
+  export let id: string = '';
+
+  /** Add a class to target with SCSS.
+   * @type {string}
+   */
+  export let cls: string = '';
+
+  /** Add a name to the <select> element.
+   * @type {string}
+   */
+  export let name: string = 'select--input';
+
   const dispatch = createEventDispatcher();
 
-  function input(event) {
+  function onChange(event) {
     const value = event.target.value;
     dispatch('select', { value });
   }
 </script>
 
-<div class="select">
+<div id="{id}" class="select {cls}">
   {#if label}
-    <label for="select--input">{label}</label>
+    <label for="{name}">{label}</label>
   {/if}
   <select
     class="select--input"
-    name="select--input"
-    id="select--input"
-    on:input="{input}"
+    name="{name}"
+    on:change="{onChange}"
+    bind:value="{selected}"
   >
     {#each options as obj}
       <option value="{obj.value}">{obj.text}</option>

--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -1,102 +1,446 @@
-<!-- @component `Select` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-Select--default) -->
+<!-- @component `Table` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-Table--default) -->
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-  import type { Option } from '../@types/global';
+  import { onMount } from 'svelte';
 
   /**
-   * The label that appears above the select input.
-   * @type {string}
+   * A source for the data.
+   * @type []
+   * @required
    */
-  export let label: string = '';
+  export let data: [];
 
   /**
-   * The label that appears above the select input.
-   * @type {Array}
+   * A title that runs above the table.
+   * @type {string}
    */
-  export let options: Option[] = [];
+  export let title: string | null = null;
 
   /**
-   * The selected value
+   * A block of text that runs above the table.
    * @type {string}
    */
-  export let selected: string | null = null;
+  export let dek: string | null = null;
 
-  /** Add an ID to target with SCSS.
+  /**
+   * A footnote that runs below the table.
    * @type {string}
    */
+  export let notes: string | null = null;
+
+  /**
+   * A source line that runs below the table.
+   * @type {string}
+   */
+  export let source: string | null = null;
+
+  /**
+   * list of the fields to include in the table. By default everything goes.
+   * @type []
+   */
+  export let includedFields: string[] = Object.keys(data[0]).filter(
+    (f) => f !== 'searchStr'
+  );
+
+  /**
+   * Whether or not the table is cutoff after a set number of rows.
+   * @type {boolean}
+   */
+  export let truncated: boolean = false;
+
+  /**
+   * If the table is truncated, how many rows to allow before the cutoff.
+   * @type {number}
+   */
+  export let truncateLength: number = 5;
+
+  /**
+   * Whether or not the table is paginated after a set number of rows.
+   * @type {boolean}
+   */
+  export let paginated: boolean = false;
+
+  /**
+   * The default page size.
+   * @type {number}
+   */
+  export let pageSize: number = 25;
+
+  /**
+   * Whether or not searches are allowed.
+   * @type {boolean}
+   */
+  export let searchable: boolean = false;
+
+  /**
+   * The placeholder text that appears in the search box.
+   * @type {string}
+   */
+  export let searchPlaceholder: string = 'Search in table';
+
+  /**
+   * A field to offer uses as an interactive filter.
+   * @type {string}
+   */
+  export let filterField: string;
+
+  /**
+   * The label to place above the filter box
+   * @type {string}
+   */
+  export let filterLabel: string;
+
+  /**
+   * Whether or not sorts are allowed.
+   * @type {boolean}
+   */
+  export let sortable: boolean = false;
+
+  /**
+   * The column to sort by. By default it's the first header.
+   * @type {string}
+   */
+  export let sortField: string = Object.keys(data[0])[0];
+
+  /**
+   * The columns that are allowed to sort. It's all of them by default.
+   * @type {string}
+   */
+  export let sortableFields: string[] = Object.keys(data[0]).filter(
+    (f) => f !== 'searchStr'
+  );
+
+  /**
+   * The direction of the sort. By default it's ascending.
+   * @type {SortDirection}
+   */
+  type SortDirection = 'ascending' | 'descending';
+  export let sortDirection: SortDirection = 'ascending';
+
+  /**
+   * Custom field formatting functions. Should be keyed to the name of the field.
+   * @type {object}
+   */
+  export let fieldFormatters: object = {};
+
+  /** Width of the component within the text well. */
+  type ContainerWidth = 'normal' | 'wide' | 'wider' | 'widest' | 'fluid';
+  export let width: ContainerWidth = 'normal';
+
+  /** Add an ID to target with SCSS. */
   export let id: string = '';
 
-  /** Add a class to target with SCSS.
-   * @type {string}
-   */
-  export let cls: string = '';
+  /** Add a class to target with SCSS. */
+  let cls: string = '';
+  export { cls as class };
 
-  /** Add a name to the <select> element.
-   * @type {string}
-   */
-  export let name: string = 'select--input';
+  /** Import local helpers */
+  import Block from '../Block/Block.svelte';
+  import Pagination from './Pagination.svelte';
+  import SearchInput from '../SearchInput/SearchInput.svelte';
+  import Select from '../Select/Select.svelte';
+  import SortArrow from './SortArrow.svelte';
+  import { filterArray, paginateArray, getOptions } from './utils.js';
 
-  const dispatch = createEventDispatcher();
+  /** Set truncate, filtering and pagination configuration */
+  let showAll = false;
+  let pageNumber = 1;
+  let searchText = '';
+  const filterList = filterField ? getOptions(data, filterField) : undefined;
+  let filterValue = '';
+  $: filteredData = filterArray(data, searchText, filterField, filterValue);
+  $: sortedData = sortArray(filteredData, sortField, sortDirection);
+  $: currentPageData = truncated
+    ? showAll
+      ? sortedData
+      : sortedData.slice(0, truncateLength + 1)
+    : paginated
+    ? paginateArray(sortedData, pageSize, pageNumber)
+    : sortedData;
 
-  function onChange(event) {
-    const value = event.target.value;
-    dispatch('select', { value });
+  //* * Handle show all, search, filter, sort and pagination events */
+  function toggleTruncate(event) {
+    showAll = !showAll;
   }
+
+  function handleSearchInput(event) {
+    searchText = event.detail.value;
+    pageNumber = 1;
+  }
+
+  function handleFilterInput(event) {
+    const value = event.detail.value;
+    filterValue = value === 'All' ? '' : value;
+    pageNumber = 1;
+  }
+
+  function handleSort(event) {
+    if (!sortable) return;
+    sortField = event.target.getAttribute('data-field');
+    sortDirection = sortDirection === 'ascending' ? 'descending' : 'ascending';
+  }
+
+  function sortArray(array, column, direction) {
+    if (!sortable) return array;
+    return array.sort((a, b) => {
+      if (a[column] < b[column]) {
+        return direction === 'ascending' ? -1 : 1;
+      } else if (a[column] > b[column]) {
+        return direction === 'ascending' ? 1 : -1;
+      } else {
+        return 0;
+      }
+    });
+  }
+
+  function formatValue(item, field) {
+    const value = item[field];
+    if (field in fieldFormatters) {
+      const func = fieldFormatters[field];
+      return func(value);
+    } else {
+      return value;
+    }
+  }
+
+  /** Boot it up. */
+  onMount(() => {
+    data.forEach((d: any) => {
+      // Compose the string we will allow users to search
+      d.searchStr = includedFields
+        .map((field) => d[field])
+        .join(' ')
+        .toLowerCase();
+    });
+  });
 </script>
 
-<div id="{id}" class="select {cls}">
-  {#if label}
-    <label for="{name}">{label}</label>
-  {/if}
-  <select
-    class="select--input"
-    name="{name}"
-    on:change="{onChange}"
-    bind:value="{selected}"
-  >
-    {#each options as obj}
-      <option value="{obj.value}">{obj.text}</option>
-    {/each}
-  </select>
-</div>
+<Block width="{width}" id="{id}" class="fmy-6 {cls}">
+  <article class="table-wrapper">
+    {#if title || dek || searchable || filterList}
+      <header class="table--header w-full">
+        {#if title}
+          <h3 class="table--header--title">{@html title}</h3>
+        {/if}
+        {#if dek}
+          <p class="table--header--dek body-note">{@html dek}</p>
+        {/if}
+        {#if searchable || filterList}
+          <nav class="input fmx-0 fmy-2">
+            {#if filterList}
+              <div class="table--header--filter">
+                <Select
+                  label="{filterLabel || filterField}"
+                  options="{filterList}"
+                  selected="{'All'}"
+                  on:select="{handleFilterInput}"
+                />
+              </div>
+            {/if}
+            {#if searchable}
+              <div class="table--header--search">
+                <SearchInput
+                  bind:searchPlaceholder="{searchPlaceholder}"
+                  on:search="{handleSearchInput}"
+                />
+              </div>
+            {/if}
+          </nav>
+        {/if}
+      </header>
+    {/if}
+    <section class="table w-full">
+      <table
+        class="w-full"
+        class:paginated="{paginated}"
+        class:truncated="{truncated &&
+          !showAll &&
+          data.length > truncateLength}"
+      >
+        <thead class="table--thead">
+          <tr>
+            {#each includedFields as field}
+              <th
+                scope="col"
+                class="table--thead--th h4 pl-0 py-2 pr-2"
+                class:sortable="{sortable && sortableFields.includes(field)}"
+                class:sort-ascending="{sortable &&
+                  sortField === field &&
+                  sortDirection === 'ascending'}"
+                class:sort-descending="{sortable &&
+                  sortField === field &&
+                  sortDirection === 'descending'}"
+                data-field="{field}"
+                on:click="{handleSort}"
+              >
+                {field}
+                {#if sortable && sortableFields.includes(field)}
+                  <div class="table--thead--sortarrow fml-1 avoid-clicks">
+                    <SortArrow
+                      bind:sortDirection="{sortDirection}"
+                      active="{sortField === field}"
+                    />
+                  </div>
+                {/if}
+              </th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody class="table--tbody">
+          {#each currentPageData as item, idx}
+            <tr data-row-index="{idx}">
+              {#each includedFields as field}
+                <td
+                  class="body-note pl-0 py-2 pr-2"
+                  data-row-index="{idx}"
+                  data-field="{field}"
+                  data-value="{item[field]}"
+                >
+                  {@html formatValue(item, field)}
+                </td>
+              {/each}
+            </tr>
+          {/each}
+          {#if searchable && searchText && currentPageData.length === 0}
+            <tr>
+              <td class="no-results" colspan="{includedFields.length}">
+                No results found for "{searchText}"
+              </td>
+            </tr>
+          {/if}
+        </tbody>
+        {#if notes || source}
+          <tfoot class="table--tfoot">
+            {#if notes}
+              <tr>
+                <td class="" colspan="{includedFields.length}">
+                  <div class="fmt-2">
+                    {@html notes}
+                  </div>
+                </td>
+              </tr>
+            {/if}
+            {#if source}
+              <tr>
+                <td class="" colspan="{includedFields.length}">
+                  <div class="fmt-1">
+                    {@html source}
+                  </div>
+                </td>
+              </tr>
+            {/if}
+          </tfoot>
+        {/if}
+      </table>
+    </section>
+    {#if truncated && data.length > truncateLength}
+      <nav
+        aria-label="Show all button"
+        class="show-all flex items-center justify-center fmt-2"
+      >
+        <button class="body-caption" on:click="{toggleTruncate}"
+          >{#if showAll}Show fewer rows{:else}Show {data.length -
+              truncateLength} more rows{/if}</button
+        >
+      </nav>
+    {/if}
+    {#if paginated}
+      <Pagination
+        bind:pageNumber="{pageNumber}"
+        bind:pageSize="{pageSize}"
+        bind:pageLength="{currentPageData.length}"
+        bind:n="{sortedData.length}"
+      />{/if}
+  </article>
+</Block>
 
 <style lang="scss">
-  @import '../../scss/colours/thematic/tr';
-  @import '../../scss/fonts/variables';
+  @import '../../scss/mixins';
 
-  .select {
-    width: 256px;
-    font-family: var(--theme-font-family-hed, $font-family-display);
-    label {
-      display: block;
-      font-size: 0.8rem;
-      font-weight: 300;
-      color: var(--theme-colour-text-primary, $tr-dark-grey);
-      padding: 0 0 0.125rem 0;
+  section.table {
+    overflow-x: auto;
+  }
+  section.table table {
+    background-color: transparent;
+    border-collapse: separate;
+    border-spacing: 0;
+    thead {
+      tr {
+        th {
+          border-bottom: 1px solid var(--theme-colour-text-primary);
+          @include bg;
+          text-align: inherit;
+          &.sortable {
+            cursor: pointer;
+            white-space: nowrap;
+          }
+          .table--thead--sortarrow {
+            display: inline-block;
+            position: relative;
+            top: 5px;
+          }
+        }
+      }
     }
-    .select--input {
-      position: relative;
-      font-size: 0.8rem;
-      font-weight: 400;
-      line-height: 1;
-      height: 33px;
-      border: 1px solid var(--theme-colour-brand-rules, $tr-muted-grey);
-      color: var(--theme-colour-text-primary, $tr-dark-grey);
-      border-radius: 6px;
-      width: 100%;
-      padding: 0.5rem;
-      -moz-appearance: none; /* Firefox */
-      -webkit-appearance: none; /* Safari and Chrome */
-      appearance: none; /* Remove the default arrow */
-      padding-right: 20px; /* Add some padding to make room for a custom arrow */
-      background: transparent;
-      background-image: url('data:image/svg+xml;utf8,<svg width="15" height="9" viewBox="0 0 15 9" xmlns="http://www.w3.org/2000/svg"><path d="M6.76474 8.30466L0.236082 1.54523C-0.0786943 1.21934 -0.0786943 0.69069 0.236082 0.364804C0.550521 0.0392666 1.19794 0.0403099 1.51305 0.364804L7.33483 6.49522L12.9249 0.475171C13.3549 0.0451683 14.1195 0.0396141 14.4339 0.365152C14.7487 0.691037 14.7487 1.21969 14.4339 1.54557L7.90492 8.30466C7.59015 8.63054 7.07952 8.63054 6.76474 8.30466Z" fill="gray"/></svg>');
-      background-repeat: no-repeat;
-      background-position-x: 235px;
-      background-position-y: 55%;
+    tbody {
+      td {
+        @include text-sm;
+        @include font-regular;
+        vertical-align: top;
+        border-bottom: 1px solid
+          var(--theme-colour-brand-rules, var(--tr-muted-grey));
+        &.no-results {
+          @include text-secondary;
+        }
+      }
     }
-    .select--input::-ms-expand {
-      display: none; /* Remove the default arrow in Internet Explorer 11 */
+    tfoot.table--tfoot {
+      tr {
+        border-bottom: 0;
+      }
+      td {
+        @include body-caption;
+      }
+    }
+    &.truncated {
+      tbody tr:last-child:not(:first-child) {
+        border-bottom: none;
+        mask-image: linear-gradient(
+          to bottom,
+          var(--theme-colour-text-primary) 0%,
+          transparent 100%
+        );
+        -webkit-mask-image: linear-gradient(
+          to bottom,
+          var(--theme-colour-text-primary) 0%,
+          transparent 100%
+        );
+      }
+    }
+  }
+
+  .avoid-clicks {
+    pointer-events: none;
+  }
+
+  nav.input {
+    padding: 0;
+    width: 100%;
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-end;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: clamp(0.31rem, calc(0.29rem + 0.1vw), 0.38rem);
+  }
+
+  nav.show-all {
+    button {
+      min-width: 13rem;
+      height: 2.15rem;
+      border: 1px solid var(--theme-colour-brand-rules, var(--tr-muted-grey));
+      border-radius: 0.25rem;
+      @include bg;
+      cursor: pointer;
     }
   }
 </style>

--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -1,446 +1,91 @@
-<!-- @component `Table` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-Table--default) -->
+<!-- @component `Select` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-Select--default) -->
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { createEventDispatcher } from 'svelte';
+  import type { Option } from '../@types/global';
 
   /**
-   * A source for the data.
-   * @type []
-   * @required
-   */
-  export let data: [];
-
-  /**
-   * A title that runs above the table.
+   * The label that appears above the select input.
    * @type {string}
    */
-  export let title: string | null = null;
+  export let label: string = '';
 
   /**
-   * A block of text that runs above the table.
+   * The label that appears above the select input.
+   * @type {Array}
+   */
+  export let options: Option[] = [];
+
+  /**
+   * The selected value
    * @type {string}
    */
-  export let dek: string | null = null;
+  export let selected: string | null = null;
 
-  /**
-   * A footnote that runs below the table.
+  /** Add an ID to target with SCSS.
    * @type {string}
    */
-  export let notes: string | null = null;
-
-  /**
-   * A source line that runs below the table.
-   * @type {string}
-   */
-  export let source: string | null = null;
-
-  /**
-   * list of the fields to include in the table. By default everything goes.
-   * @type []
-   */
-  export let includedFields: string[] = Object.keys(data[0]).filter(
-    (f) => f !== 'searchStr'
-  );
-
-  /**
-   * Whether or not the table is cutoff after a set number of rows.
-   * @type {boolean}
-   */
-  export let truncated: boolean = false;
-
-  /**
-   * If the table is truncated, how many rows to allow before the cutoff.
-   * @type {number}
-   */
-  export let truncateLength: number = 5;
-
-  /**
-   * Whether or not the table is paginated after a set number of rows.
-   * @type {boolean}
-   */
-  export let paginated: boolean = false;
-
-  /**
-   * The default page size.
-   * @type {number}
-   */
-  export let pageSize: number = 25;
-
-  /**
-   * Whether or not searches are allowed.
-   * @type {boolean}
-   */
-  export let searchable: boolean = false;
-
-  /**
-   * The placeholder text that appears in the search box.
-   * @type {string}
-   */
-  export let searchPlaceholder: string = 'Search in table';
-
-  /**
-   * A field to offer uses as an interactive filter.
-   * @type {string}
-   */
-  export let filterField: string;
-
-  /**
-   * The label to place above the filter box
-   * @type {string}
-   */
-  export let filterLabel: string;
-
-  /**
-   * Whether or not sorts are allowed.
-   * @type {boolean}
-   */
-  export let sortable: boolean = false;
-
-  /**
-   * The column to sort by. By default it's the first header.
-   * @type {string}
-   */
-  export let sortField: string = Object.keys(data[0])[0];
-
-  /**
-   * The columns that are allowed to sort. It's all of them by default.
-   * @type {string}
-   */
-  export let sortableFields: string[] = Object.keys(data[0]).filter(
-    (f) => f !== 'searchStr'
-  );
-
-  /**
-   * The direction of the sort. By default it's ascending.
-   * @type {SortDirection}
-   */
-  type SortDirection = 'ascending' | 'descending';
-  export let sortDirection: SortDirection = 'ascending';
-
-  /**
-   * Custom field formatting functions. Should be keyed to the name of the field.
-   * @type {object}
-   */
-  export let fieldFormatters: object = {};
-
-  /** Width of the component within the text well. */
-  type ContainerWidth = 'normal' | 'wide' | 'wider' | 'widest' | 'fluid';
-  export let width: ContainerWidth = 'normal';
-
-  /** Add an ID to target with SCSS. */
   export let id: string = '';
 
-  /** Add a class to target with SCSS. */
-  let cls: string = '';
-  export { cls as class };
+  /** Add a class to target with SCSS.
+   * @type {string}
+   */
+  export let cls: string = '';
 
-  /** Import local helpers */
-  import Block from '../Block/Block.svelte';
-  import Pagination from './Pagination.svelte';
-  import SearchInput from '../SearchInput/SearchInput.svelte';
-  import Select from '../Select/Select.svelte';
-  import SortArrow from './SortArrow.svelte';
-  import { filterArray, paginateArray, getOptions } from './utils.js';
+  /** Add a name to the <select> element.
+   * @type {string}
+   */
+  export let name: string = 'select--input';
 
-  /** Set truncate, filtering and pagination configuration */
-  let showAll = false;
-  let pageNumber = 1;
-  let searchText = '';
-  const filterList = filterField ? getOptions(data, filterField) : undefined;
-  let filterValue = '';
-  $: filteredData = filterArray(data, searchText, filterField, filterValue);
-  $: sortedData = sortArray(filteredData, sortField, sortDirection);
-  $: currentPageData = truncated
-    ? showAll
-      ? sortedData
-      : sortedData.slice(0, truncateLength + 1)
-    : paginated
-    ? paginateArray(sortedData, pageSize, pageNumber)
-    : sortedData;
+  const dispatch = createEventDispatcher();
 
-  //* * Handle show all, search, filter, sort and pagination events */
-  function toggleTruncate(event) {
-    showAll = !showAll;
+  function onChange(event) {
+    const value = event.target.value;
+    dispatch('select', { value });
   }
-
-  function handleSearchInput(event) {
-    searchText = event.detail.value;
-    pageNumber = 1;
-  }
-
-  function handleFilterInput(event) {
-    const value = event.detail.value;
-    filterValue = value === 'All' ? '' : value;
-    pageNumber = 1;
-  }
-
-  function handleSort(event) {
-    if (!sortable) return;
-    sortField = event.target.getAttribute('data-field');
-    sortDirection = sortDirection === 'ascending' ? 'descending' : 'ascending';
-  }
-
-  function sortArray(array, column, direction) {
-    if (!sortable) return array;
-    return array.sort((a, b) => {
-      if (a[column] < b[column]) {
-        return direction === 'ascending' ? -1 : 1;
-      } else if (a[column] > b[column]) {
-        return direction === 'ascending' ? 1 : -1;
-      } else {
-        return 0;
-      }
-    });
-  }
-
-  function formatValue(item, field) {
-    const value = item[field];
-    if (field in fieldFormatters) {
-      const func = fieldFormatters[field];
-      return func(value);
-    } else {
-      return value;
-    }
-  }
-
-  /** Boot it up. */
-  onMount(() => {
-    data.forEach((d: any) => {
-      // Compose the string we will allow users to search
-      d.searchStr = includedFields
-        .map((field) => d[field])
-        .join(' ')
-        .toLowerCase();
-    });
-  });
 </script>
 
-<Block width="{width}" id="{id}" class="fmy-6 {cls}">
-  <article class="table-wrapper">
-    {#if title || dek || searchable || filterList}
-      <header class="table--header w-full">
-        {#if title}
-          <h3 class="table--header--title">{@html title}</h3>
-        {/if}
-        {#if dek}
-          <p class="table--header--dek body-note">{@html dek}</p>
-        {/if}
-        {#if searchable || filterList}
-          <nav class="input fmx-0 fmy-2">
-            {#if filterList}
-              <div class="table--header--filter">
-                <Select
-                  label="{filterLabel || filterField}"
-                  options="{filterList}"
-                  selected="{'All'}"
-                  on:select="{handleFilterInput}"
-                />
-              </div>
-            {/if}
-            {#if searchable}
-              <div class="table--header--search">
-                <SearchInput
-                  bind:searchPlaceholder="{searchPlaceholder}"
-                  on:search="{handleSearchInput}"
-                />
-              </div>
-            {/if}
-          </nav>
-        {/if}
-      </header>
-    {/if}
-    <section class="table w-full">
-      <table
-        class="w-full"
-        class:paginated="{paginated}"
-        class:truncated="{truncated &&
-          !showAll &&
-          data.length > truncateLength}"
-      >
-        <thead class="table--thead">
-          <tr>
-            {#each includedFields as field}
-              <th
-                scope="col"
-                class="table--thead--th h4 pl-0 py-2 pr-2"
-                class:sortable="{sortable && sortableFields.includes(field)}"
-                class:sort-ascending="{sortable &&
-                  sortField === field &&
-                  sortDirection === 'ascending'}"
-                class:sort-descending="{sortable &&
-                  sortField === field &&
-                  sortDirection === 'descending'}"
-                data-field="{field}"
-                on:click="{handleSort}"
-              >
-                {field}
-                {#if sortable && sortableFields.includes(field)}
-                  <div class="table--thead--sortarrow fml-1 avoid-clicks">
-                    <SortArrow
-                      bind:sortDirection="{sortDirection}"
-                      active="{sortField === field}"
-                    />
-                  </div>
-                {/if}
-              </th>
-            {/each}
-          </tr>
-        </thead>
-        <tbody class="table--tbody">
-          {#each currentPageData as item, idx}
-            <tr data-row-index="{idx}">
-              {#each includedFields as field}
-                <td
-                  class="body-note pl-0 py-2 pr-2"
-                  data-row-index="{idx}"
-                  data-field="{field}"
-                  data-value="{item[field]}"
-                >
-                  {@html formatValue(item, field)}
-                </td>
-              {/each}
-            </tr>
-          {/each}
-          {#if searchable && searchText && currentPageData.length === 0}
-            <tr>
-              <td class="no-results" colspan="{includedFields.length}">
-                No results found for "{searchText}"
-              </td>
-            </tr>
-          {/if}
-        </tbody>
-        {#if notes || source}
-          <tfoot class="table--tfoot">
-            {#if notes}
-              <tr>
-                <td class="" colspan="{includedFields.length}">
-                  <div class="fmt-2">
-                    {@html notes}
-                  </div>
-                </td>
-              </tr>
-            {/if}
-            {#if source}
-              <tr>
-                <td class="" colspan="{includedFields.length}">
-                  <div class="fmt-1">
-                    {@html source}
-                  </div>
-                </td>
-              </tr>
-            {/if}
-          </tfoot>
-        {/if}
-      </table>
-    </section>
-    {#if truncated && data.length > truncateLength}
-      <nav
-        aria-label="Show all button"
-        class="show-all flex items-center justify-center fmt-2"
-      >
-        <button class="body-caption" on:click="{toggleTruncate}"
-          >{#if showAll}Show fewer rows{:else}Show {data.length -
-              truncateLength} more rows{/if}</button
-        >
-      </nav>
-    {/if}
-    {#if paginated}
-      <Pagination
-        bind:pageNumber="{pageNumber}"
-        bind:pageSize="{pageSize}"
-        bind:pageLength="{currentPageData.length}"
-        bind:n="{sortedData.length}"
-      />{/if}
-  </article>
-</Block>
+<div id="{id}" class="select {cls}">
+  {#if label}
+    <label class="body-caption block" for="select--input">{label}</label>
+  {/if}
+  <select
+    class="select--input body-caption fpx-2"
+    name="{name}"
+    on:input="{input}"
+    on:change="{onChange}"
+    bind:value="{selected}"
+  >
+    {#each options as obj}
+      <option value="{obj.value}">{obj.text}</option>
+    {/each}
+  </select>
+</div>
 
 <style lang="scss">
   @import '../../scss/mixins';
 
-  section.table {
-    overflow-x: auto;
-  }
-  section.table table {
-    background-color: transparent;
-    border-collapse: separate;
-    border-spacing: 0;
-    thead {
-      tr {
-        th {
-          border-bottom: 1px solid var(--theme-colour-text-primary);
-          @include bg;
-          text-align: inherit;
-          &.sortable {
-            cursor: pointer;
-            white-space: nowrap;
-          }
-          .table--thead--sortarrow {
-            display: inline-block;
-            position: relative;
-            top: 5px;
-          }
-        }
-      }
-    }
-    tbody {
-      td {
-        @include text-sm;
-        @include font-regular;
-        vertical-align: top;
-        border-bottom: 1px solid
-          var(--theme-colour-brand-rules, var(--tr-muted-grey));
-        &.no-results {
-          @include text-secondary;
-        }
-      }
-    }
-    tfoot.table--tfoot {
-      tr {
-        border-bottom: 0;
-      }
-      td {
-        @include body-caption;
-      }
-    }
-    &.truncated {
-      tbody tr:last-child:not(:first-child) {
-        border-bottom: none;
-        mask-image: linear-gradient(
-          to bottom,
-          var(--theme-colour-text-primary) 0%,
-          transparent 100%
-        );
-        -webkit-mask-image: linear-gradient(
-          to bottom,
-          var(--theme-colour-text-primary) 0%,
-          transparent 100%
-        );
-      }
-    }
-  }
+  .select {
+    width: 250px;
 
-  .avoid-clicks {
-    pointer-events: none;
-  }
-
-  nav.input {
-    padding: 0;
-    width: 100%;
-    display: flex;
-    justify-content: flex-start;
-    align-items: flex-end;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: clamp(0.31rem, calc(0.29rem + 0.1vw), 0.38rem);
-  }
-
-  nav.show-all {
-    button {
-      min-width: 13rem;
+    .select--input {
+      position: relative;
       height: 2.15rem;
       border: 1px solid var(--theme-colour-brand-rules, var(--tr-muted-grey));
       border-radius: 0.25rem;
-      @include bg;
-      cursor: pointer;
+      width: 100%;
+
+      -moz-appearance: none; /* Firefox */
+      -webkit-appearance: none; /* Safari and Chrome */
+      appearance: none; /* Remove the default arrow */
+
+      background: transparent;
+      background-image: url('data:image/svg+xml;utf8,<svg width="15" height="9" viewBox="0 0 15 9" xmlns="http://www.w3.org/2000/svg"><path d="M6.76474 8.30466L0.236082 1.54523C-0.0786943 1.21934 -0.0786943 0.69069 0.236082 0.364804C0.550521 0.0392666 1.19794 0.0403099 1.51305 0.364804L7.33483 6.49522L12.9249 0.475171C13.3549 0.0451683 14.1195 0.0396141 14.4339 0.365152C14.7487 0.691037 14.7487 1.21969 14.4339 1.54557L7.90492 8.30466C7.59015 8.63054 7.07952 8.63054 6.76474 8.30466Z" fill="gray"/></svg>');
+      background-repeat: no-repeat;
+      background-position-x: 225px;
+      background-position-y: 55%;
+    }
+    .select--input::-ms-expand {
+      display: none; /* Remove the default arrow in Internet Explorer 11 */
     }
   }
 </style>

--- a/src/components/Select/stories/docs/component.md
+++ b/src/components/Select/stories/docs/component.md
@@ -23,5 +23,5 @@ Invite users to pick an option from a predefined list.
   ];
 </script>
 
-<select options="{optionList}" />
+<Select options="{optionList}" />
 ```

--- a/src/components/Select/stories/docs/component.md
+++ b/src/components/Select/stories/docs/component.md
@@ -1,0 +1,27 @@
+Invite users to pick an option from a predefined list.
+
+---
+
+```html
+<script>
+  import { Select } from '@reuters-graphics/graphics-components';
+
+  // Options must be provided as a list of objects with `text` and `value` keys.
+  const optionList = [
+    {
+      text: 'Red', // The `text` key is what is displayed to the user.
+      value: 'r', // The `value` key is what is passed to the `selected` property.
+    },
+    {
+      text: 'Blue',
+      value: 'b',
+    },
+    {
+      text: 'Green',
+      value: 'g',
+    },
+  ];
+</script>
+
+<select options="{optionList}" />
+```

--- a/src/components/Select/stories/docs/default.md
+++ b/src/components/Select/stories/docs/default.md
@@ -20,5 +20,5 @@ This argument lets you set the option that is `selected` by default. It expects 
   ];
 </script>
 
-<select selected="{'g'}" options="{optionList}" />
+<Select selected="{'g'}" options="{optionList}" />
 ```

--- a/src/components/Select/stories/docs/default.md
+++ b/src/components/Select/stories/docs/default.md
@@ -1,0 +1,24 @@
+This argument lets you set the option that is `selected` by default. It expects that you pass the `value` of the option you want.
+
+```html
+<script>
+  import { Select } from '@reuters-graphics/graphics-components';
+
+  const optionList = [
+    {
+      text: 'Red',
+      value: 'r',
+    },
+    {
+      text: 'Blue',
+      value: 'b',
+    },
+    {
+      text: 'Green',
+      value: 'g',
+    },
+  ];
+</script>
+
+<select selected="{'g'}" options="{optionList}" />
+```

--- a/src/components/Select/stories/docs/label.md
+++ b/src/components/Select/stories/docs/label.md
@@ -20,5 +20,5 @@ You have the option of including a `label` argument that will appear above the p
   ];
 </script>
 
-<select label="{'Pick a color'}" options="{optionList}" />
+<Select label="{'Pick a color'}" options="{optionList}" />
 ```

--- a/src/components/Select/stories/docs/label.md
+++ b/src/components/Select/stories/docs/label.md
@@ -1,0 +1,24 @@
+You have the option of including a `label` argument that will appear above the pulldown menu.
+
+```html
+<script>
+  import { Select } from '@reuters-graphics/graphics-components';
+
+  const optionList = [
+    {
+      text: 'Red',
+      value: 'r',
+    },
+    {
+      text: 'Blue',
+      value: 'b',
+    },
+    {
+      text: 'Green',
+      value: 'g',
+    },
+  ];
+</script>
+
+<select label="{'Pick a color'}" options="{optionList}" />
+```

--- a/src/components/Table/Table.svelte
+++ b/src/components/Table/Table.svelte
@@ -136,7 +136,7 @@
   import Block from '../Block/Block.svelte';
   import Pagination from './Pagination.svelte';
   import SearchInput from '../SearchInput/SearchInput.svelte';
-  import Select from './Select.svelte';
+  import Select from '../Select/Select.svelte';
   import SortArrow from './SortArrow.svelte';
   import { filterArray, paginateArray, getOptions } from './utils.js';
 
@@ -230,6 +230,7 @@
                 <Select
                   label="{filterLabel || filterField}"
                   options="{filterList}"
+                  selected="{'All'}"
                   on:select="{handleFilterInput}"
                 />
               </div>

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export { default as ReutersGraphicsLogo } from './components/ReutersGraphicsLogo
 export { default as ReutersLogo } from './components/ReutersLogo/ReutersLogo.svelte';
 export { default as Scroller } from './components/Scroller/Scroller.svelte';
 export { default as SearchInput } from './components/SearchInput/SearchInput.svelte';
+export { default as Select } from './components/Select/Select.svelte';
 export { default as SEO } from './components/SEO/SEO.svelte';
 export { default as Sharer } from './components/Sharer/Sharer.svelte';
 export { default as SimpleTimeline } from './components/SimpleTimeline/SimpleTimeline.svelte';


### PR DESCRIPTION
### What's in this pull request

- [ ] Bug fix
- [x] New component/feature
- [ ] Documentation update
- [ ] Other

### Description

This crowbars the Select component created for the Table out so it can be used on its own.

### Before submitting, please check that you've

- [x] Read our [contributing guide](https://github.com/reuters-graphics/graphics-components/blob/master/CONTRIBUTING.md) at some point
- [x] Formatted you code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Tagged an editor to review
