### PR TITLE
Japanese

### DIFF
--- a/src/components/SiteFooter/CompanyLinks.svelte
+++ b/src/components/SiteFooter/CompanyLinks.svelte
@@ -15,17 +15,32 @@
   };
 
   export let links = {};
+  export let lang = 'en';
+
+  const labels = {
+    'Information you can trust': {
+      default: 'Information you can trust',
+      ja: '信頼されるメディアとして',
+    },
+    'Follow Us': {
+      default: 'Follow Us',
+      ja: 'ロイターをフォロー',
+    },
+  };
 </script>
 
 {#if links.social_links}
   <section class="company">
     <div class="content-container">
       <article class="company-info">
-        <h2>Information you can trust</h2>
+        <h2>
+          {labels['Information you can trust'][lang] ||
+            labels['Information you can trust'].default}
+        </h2>
         <p>{links.company_description}</p>
       </article>
       <div class="social">
-        <h2>Follow Us</h2>
+        <h2>{labels['Follow Us'][lang] || labels['Follow Us'].default}</h2>
         <div>
           <ul class="links">
             {#each links.social_links as link}

--- a/src/components/SiteFooter/LegalLinks.svelte
+++ b/src/components/SiteFooter/LegalLinks.svelte
@@ -1,17 +1,19 @@
 <script>
-  import { normalizeUrl } from '../SiteHeader/NavBar/utils';
+  import { normalizeUrl, normalizeUrlJp } from '../SiteHeader/NavBar/utils';
 
   export let links = {};
+  export let lang = 'en';
+  const normaliseUrl = lang === 'ja' ? normalizeUrlJp : normalizeUrl;
 </script>
 
 {#if links.ad_links}
-  <section class="legal">
+  <section class="legal" lang="{lang}">
     <div class="content-container">
       <section class="ad-links">
         <ul class="link-group">
           {#each links.ad_links as link}
             <li>
-              <a href="{normalizeUrl(link.url)}">
+              <a href="{normaliseUrl(link.url)}">
                 {link.text}
               </a>
             </li>
@@ -19,16 +21,23 @@
         </ul>
       </section>
       <p class="disclaimer">
-        All quotes delayed a minimum of 15 minutes. <a
-          href="{normalizeUrl(links.disclaimer_link)}"
-          >See here for a complete list of exchanges and delays</a
-        >.
+        {#if lang === 'ja'}
+          掲載の情報は15分以上の遅れで表示しています。<a
+            href="{normalizeUrl(links.disclaimer_link)}"
+            >詳しくはこちらをご確認ください</a
+          >。
+        {:else}
+          All quotes delayed a minimum of 15 minutes. <a
+            href="{normalizeUrl(links.disclaimer_link)}"
+            >See here for a complete list of exchanges and delays</a
+          >.
+        {/if}
       </p>
       <section class="misc-links">
         <ul class="link-group">
           {#each links.misc_links.filter((d) => !d.self) as link}
             <li>
-              <a href="{normalizeUrl(link.url)}">
+              <a href="{normaliseUrl(link.url)}">
                 {link.text}
               </a>
             </li>
@@ -37,7 +46,7 @@
       </section>
       <p class="copyright">
         © {links.copyright_year} Reuters.
-        <a href="{normalizeUrl(links.copyright_link)}">All rights reserved</a>
+        <a href="{normaliseUrl(links.copyright_link)}">All rights reserved</a>
       </p>
     </div>
   </section>
@@ -161,6 +170,15 @@
     color: var(--nav-primary);
     a {
       color: inherit;
+    }
+  }
+  .legal {
+    &[lang='ja'] {
+      .link-group {
+        a {
+          font-weight: 600;
+        }
+      }
     }
   }
 </style>

--- a/src/components/SiteFooter/QuickLinks.svelte
+++ b/src/components/SiteFooter/QuickLinks.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { normalizeUrl } from '../SiteHeader/NavBar/utils';
+  import { normalizeUrl, normalizeUrlJp } from '../SiteHeader/NavBar/utils';
 
   import Graphics from './svgs/Graphics.svelte';
   import Pictures from './svgs/Pictures.svelte';
@@ -12,38 +12,51 @@
   };
 
   export let links = {};
+  export let lang = 'en';
+  const normaliseUrl = lang === 'ja' ? normalizeUrlJp : normalizeUrl;
 
   let windowWidth = 1200;
   const mobileBreakpoint = 745;
+
+  const labels = {
+    'Site Index': { default: 'Site Index', ja: 'サイトインデックス' },
+    Latest: { default: 'Latest', ja: '最新' },
+    Media: { default: 'Media', ja: 'メディア' },
+    Browse: { default: 'Browse', ja: 'ブラウズ' },
+    'About Reuters': { default: 'About Reuters', ja: 'ロイターについて' },
+    'Stay Informed': { default: 'Stay Informed', ja: '最新情報を入手' },
+  };
 </script>
 
 <svelte:window bind:innerWidth="{windowWidth}" />
 
 {#if links.latest_links}
-  <section class="quick-links">
-    <h2 class="visually-hidden">Site Index</h2>
+  <section class="quick-links" lang="{lang}">
+    <h2 class="visually-hidden">
+      {labels['Site Index'][lang] || labels['Site Index'].default}
+    </h2>
     <div class="content-container">
       {#if windowWidth < mobileBreakpoint}
         <div class="latest-and-media">
           <section class="link-group">
-            <h3>Latest</h3>
+            <h3>{labels.Latest[lang] || labels.Latest.default}</h3>
             <ul>
               {#each links.latest_links as link}
                 <li>
-                  <a href="{normalizeUrl(link.url)}">{link.text}</a>
+                  <a href="{normaliseUrl(link.url)}">{link.text}</a>
                 </li>
               {/each}
             </ul>
           </section>
           <section class="link-group media">
-            <h3>Media</h3>
+            <h3>{labels.Media[lang] || labels.Media.default}</h3>
             <ul>
               {#each links.media_links as link}
                 <li>
                   <div class="symbol">
                     <svelte:component this="{symbols[link.symbol]}" />
                   </div>
-                  <a href="{normalizeUrl(link.url)}">
+                  <a href="{normaliseUrl(link.url)}">
                     {link.text}
                   </a>
                 </li>
@@ -53,11 +66,11 @@
         </div>
       {:else}
         <section class="link-group">
-          <h3>Latest</h3>
+          <h3>{labels.Latest[lang] || labels.Latest.default}</h3>
           <ul>
             {#each links.latest_links as link}
               <li>
-                <a href="{normalizeUrl(link.url)}">{link.text}</a>
+                <a href="{normaliseUrl(link.url)}">{link.text}</a>
               </li>
             {/each}
           </ul>
@@ -65,25 +78,25 @@
       {/if}
 
       <section class="link-group">
-        <h3>Browse</h3>
+        <h3>{labels.Browse[lang] || labels.Browse.default}</h3>
         <ul>
           {#each links.browse_links as link}
             <li>
-              <a href="{normalizeUrl(link.url)}">{link.text}</a>
+              <a href="{normaliseUrl(link.url)}">{link.text}</a>
             </li>
           {/each}
         </ul>
       </section>
       {#if windowWidth >= mobileBreakpoint}
         <section class="link-group media">
-          <h3>Media</h3>
+          <h3>{labels.Media[lang] || labels.Media.default}</h3>
           <ul>
             {#each links.media_links as link}
               <li>
                 <div class="symbol">
                   <svelte:component this="{symbols[link.symbol]}" />
                 </div>
-                <a href="{normalizeUrl(link.url)}">
+                <a href="{normaliseUrl(link.url)}">
                   {link.text}
                 </a>
               </li>
@@ -93,21 +106,25 @@
       {/if}
       <div class="about-and-stay-informed">
         <section class="about">
-          <h3>About Reuters</h3>
+          <h3>
+            {labels['About Reuters'][lang] || labels['About Reuters'].default}
+          </h3>
           <ul>
             {#each links.about_links as link}
               <li>
-                <a href="{normalizeUrl(link.url)}">{link.text}</a>
+                <a href="{normaliseUrl(link.url)}">{link.text}</a>
               </li>
             {/each}
           </ul>
         </section>
         <section class="stay-informed">
-          <h3>Stay Informed</h3>
+          <h3>
+            {labels['Stay Informed'][lang] || labels['Stay Informed'].default}
+          </h3>
           <ul>
             {#each links.stay_informed_links as link}
               <li>
-                <a href="{normalizeUrl(link.url)}">{link.text}</a>
+                <a href="{normaliseUrl(link.url)}">{link.text}</a>
               </li>
             {/each}
           </ul>
@@ -133,6 +150,11 @@
     padding-top: 24px;
     padding-bottom: 24px;
     box-sizing: border-box;
+    &[lang='ja'] {
+      a {
+        font-weight: 600;
+      }
+    }
 
     .content-container {
       @include responsive-columns(12);

--- a/src/components/SiteFooter/SiteFooter.stories.svelte
+++ b/src/components/SiteFooter/SiteFooter.stories.svelte
@@ -1,4 +1,6 @@
 <script>
+  // @ts-nocheck
+
   import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
 
   // @ts-ignore
@@ -7,6 +9,8 @@
   import darkThemeDocs from './stories/docs/darkTheme.md?raw';
   // @ts-ignore
   import customReferralsDocs from './stories/docs/customReferrals.md?raw';
+  // @ts-ignore
+  import japanese from './stories/docs/japanese.md?raw';
 
   import SiteFooter from './SiteFooter.svelte';
   import Theme from '../Theme/Theme.svelte';
@@ -63,6 +67,12 @@
   }}"
   {...withStoryDocs(customReferralsDocs)}
 />
+
+<Story name="Japanese" {...withStoryDocs(japanese)}>
+  <div>
+    <SiteFooter lang="ja" />
+  </div>
+</Story>
 
 <style>
   div {

--- a/src/components/SiteFooter/SiteFooter.svelte
+++ b/src/components/SiteFooter/SiteFooter.svelte
@@ -6,6 +6,7 @@
   import Referrals from './Referrals/index.svelte';
 
   import starterData from './data.json';
+  import starterDataJp from './data-jp.json';
   import { onMount } from 'svelte';
 
   interface Referral {
@@ -19,8 +20,15 @@
    * Custom referrals to other Reuters Graphics projects
    */
   export let referrals: Referral[] = [];
+  export let lang = 'en';
 
-  let data = starterData;
+  let data = lang === 'ja' ? starterDataJp : starterData;
+  const domain = lang === 'ja' ? 'jp' : 'www';
+  const website = lang === 'ja' ? 'reuters-japan' : 'reuters';
+  const font =
+    lang === 'ja'
+      ? '-apple-system, "Hiragino Kaku Gothic Pro", "Meiryo", "MS Pgothic", helvetica, arial, sans-serif'
+      : 'Knowledge';
 
   onMount(async () => {
     if (new URL(document.location.href).origin !== 'https://www.reuters.com') {
@@ -28,9 +36,9 @@
     }
     try {
       const response = await fetch(
-        'https://www.reuters.com/site-api/footer/?' +
+        `https://${domain}.reuters.com/site-api/footer/?` +
           new URLSearchParams({
-            _website: 'reuters',
+            _website: website,
             outputType: 'json',
           })
       );
@@ -50,14 +58,16 @@
     --nav-background: var(--theme-colour-background, #fff);
     --nav-primary: var(--theme-colour-text-primary, #404040);
     --nav-rules: var(--theme-colour-brand-rules, #d0d0d0);
-    --theme-font-family-sans-serif: Knowledge, sans-serif;
+    --theme-font-family-sans-serif: ${font}, sans-serif;
   `}"
 >
   <div>
-    <Referrals referrals="{referrals}" />
-    <QuickLinks links="{data[0]}" />
-    <CompanyLinks links="{data[0]}" />
-    <LegalLinks links="{data[0]}" />
+    {#if lang !== 'ja'}
+      <Referrals referrals="{referrals}" />
+    {/if}
+    <QuickLinks links="{data[0]}" lang="{lang}" />
+    <CompanyLinks links="{data[0]}" lang="{lang}" />
+    <LegalLinks links="{data[0]}" lang="{lang}" />
   </div>
 </footer>
 

--- a/src/components/SiteFooter/data-jp.json
+++ b/src/components/SiteFooter/data-jp.json
@@ -1,0 +1,186 @@
+[
+    {
+        "company_description": "ロイターは、トムソン・ロイターのニュース・メディア部門で、毎日世界各地の数十億人にリーチする世界最大級の国際マルチメディア通信社です。デスクトップ端末、世界の報道メディア、業界イベント、そしてダイレクトにビジネス、金融、国内・国際ニュースをプロフェッショナルにお届けします。",
+        "disclaimer_link": "/info-pages/disclaimer/",
+        "copyright_link": "https://www.thomsonreuters.com/en/policies/copyright.html",
+        "copyright_year": "2023",
+        "latest_links": [
+            {
+                "text": "ホーム",
+                "url": "/",
+                "self": true
+            }
+        ],
+        "browse_links": [
+            {
+                "text": "ワールド",
+                "url": "/world/",
+                "self": true
+            },
+            {
+                "text": "マーケット",
+                "url": "/markets/",
+                "self": true
+            },
+            {
+                "text": "経済",
+                "url": "/economy/",
+                "self": true
+            },
+            {
+                "text": "ビジネス",
+                "url": "/business/",
+                "self": true
+            },
+            {
+                "text": "オピニオン",
+                "url": "/opinion/",
+                "self": true
+            },
+            {
+                "text": "ライフ",
+                "url": "/life/",
+                "self": true
+            },
+            {
+                "text": "スポーツ",
+                "url": "/life/sports/",
+                "self": true
+            }
+        ],
+        "key_topics_links": [
+            {
+                "text": "The Great Reboot",
+                "url": "/world/the-great-reboot/",
+                "self": true
+            }
+        ],
+        "media_links": [
+            {
+                "text": "ビデオ",
+                "url": "/video/",
+                "symbol": "videos"
+            },
+            {
+                "text": "写真",
+                "url": "/pictures",
+                "symbol": "pictures",
+                "self": true
+            }
+        ],
+        "about_links": [
+            {
+                "text": "ロイターについて",
+                "url": "https://www.reutersagency.com/ja/about/about-us/"
+            },
+            {
+                "text": "採用情報",
+                "url": "https://thomsonreuters.com/en/careers.html"
+            },
+            {
+                "text": "ロイター・ニュース・エージェンシー",
+                "url": "https://www.reutersagency.com/ja"
+            },
+            {
+                "text": "ブランド・ガイドライン",
+                "url": "https://www.reutersagency.com/ja/about/brand-attribution-guidelines/"
+            },
+            {
+                "text": "リーダーシップチーム",
+                "url": "https://www.reutersagency.com/ja/about/leadership-team/"
+            }
+        ],
+        "stay_informed_links": [
+            {
+                "text": "ニュースメール",
+                "url": "https://newslink.jp.reuters.com/join/subscribe"
+            }
+        ],
+        "social_links": [
+            {
+                "type": "twitter",
+                "url": "https://twitter.com/ReutersJapan"
+            },
+            {
+                "type": "facebook",
+                "url": "https://www.facebook.com/ReutersJapan"
+            },
+            {
+                "type": "instagram",
+                "url": "https://www.instagram.com/reutersjapan/"
+            },
+            {
+                "type": "youtube",
+                "url": "https://www.youtube.com/c/ReutersJapan/videos"
+            },
+            {
+                "type": "linkedin",
+                "url": "https://www.linkedin.com/company/10256858/"
+            }
+        ],
+        "tr_products": [
+            {
+                "name": "ONESOURCE Global Trade",
+                "description": "安全保障貿易管理をはじめとする輸出管理、EPA/FTAを活用した関税削減の自動化、日々複雑化する規制及び貿易コンプライアンスに関する最新情報の提供、またそれらを一元管理する包括的ソリューションです。",
+                "url": "https://www.thomsonreuters.co.jp/ja/products-services/global-trade.html"
+            },
+            {
+                "name": "ONESOURCE Global Tax",
+                "description": "国際税務のコンプライアンスを確保しリスクを低減、また業務効率化をサポートするグローバル企業のための税務自動化ソリューションです。",
+                "url": "https://www.thomsonreuters.co.jp/ja/products-services/tax-accounting.html"
+            },
+            {
+                "name": "Legal Tracker",
+                "description": "法律事務所からの請求の電子化（eBilling）、APとの連携による作業、ならびにリアルタイムの弁護士費用管理で効果的な案件管理とコスト低減を支援する企業法務に最適なDXソリューションです。",
+                "url": "https://www.thomsonreuters.co.jp/ja/products-services/legal/legal-tracker.html"
+            }
+        ],
+        "ad_links": [
+            {
+                "text": "広告掲載について",
+                "url": "https://www.reutersagency.com/ja/services/advertising-solutions/"
+            },
+            {
+                "text": "広告掲載ポリシー",
+                "url": "/info-pages/advertising-guidelines/"
+            }
+        ],
+        "misc_links": [
+            {
+                "text": "クッキー",
+                "url": "https://www.thomsonreuters.com/ja/privacy-statement.html#cookies"
+            },
+            {
+                "text": "ロイター利用規約（英語）",
+                "url": "/info-pages/terms-of-use/"
+            },
+            {
+                "text": "個人情報保護方針",
+                "url": "https://www.thomsonreuters.com/jp/privacy-statement.html"
+            },
+            {
+                "text": "ウェブアクセシビリティ（英語）",
+                "url": "https://www.thomsonreuters.com/en/policies/digital-accessibility-policy.html"
+            },
+            {
+                "text": "お問い合わせ先",
+                "url": "/info-pages/contact-us/"
+            },
+            {
+                "text": "フィードバック",
+                "url": "https://trdigital.iad1.qualtrics.com/jfe/form/SV_8kte8gArGyCGVhz"
+            },
+            {
+                "url": "javascript:window.OneTrust.ToggleInfoDisplay();",
+                "self": "true",
+                "text": "私の個人情報を販売または共有せず、機密性の高い個人情報の使用を制限する。"
+            }
+        ],
+        "do_not_sell_info": {
+            "ccpa": "私の個人情報を販売または共有せず、機密性の高い個人情報の使用を制限する。",
+            "vcdpa": "ターゲット広告をオプトアウト（無効化）する。",
+            "cpa": "私の個人情報を販売または共有せず、機密性の高い個人情報の使用を制限する。",
+            "ctdpa": "私の個人情報を販売または共有せず、機密性の高い個人情報の使用を制限する。"
+        }
+    }
+]

--- a/src/components/SiteFooter/data.json
+++ b/src/components/SiteFooter/data.json
@@ -3,7 +3,7 @@
         "company_description": "Reuters, the news and media division of Thomson Reuters, is the world’s largest multimedia news provider, reaching billions of people worldwide every day. Reuters provides business, financial, national and international news to professionals via desktop terminals, the world's media organizations, industry events and directly to consumers.",
         "disclaimer_link": "https://www.reuters.com/info-pages/disclaimer/",
         "copyright_link": "https://www.thomsonreuters.com/en/policies/copyright.html",
-        "copyright_year": "2022",
+        "copyright_year": "2023",
         "latest_links": [
             {
                 "text": "Home",

--- a/src/components/SiteFooter/stories/docs/japanese.md
+++ b/src/components/SiteFooter/stories/docs/japanese.md
@@ -1,0 +1,9 @@
+lang="ja"を設定することで日本語のフッターに変更することができます。
+
+```svelte
+<script>
+  import { SiteFooter } from '@reuters-graphics/graphics-components';
+</script>
+
+<SiteFooter lang="ja" />
+```

--- a/src/components/SiteHeader/MobileMenu/index.svelte
+++ b/src/components/SiteHeader/MobileMenu/index.svelte
@@ -6,6 +6,7 @@
   export let data = [];
   export let isMobileMenuOpen = false;
   export let releaseMobileMenu = () => {};
+  export let lang = 'en';
 </script>
 
 {#if isMobileMenuOpen}
@@ -20,7 +21,7 @@
       --nav-shadow: 0 1px 4px 2px var(--theme-colour-brand-shadow, rgb(255 255 255 / 10%));
     `}"
   >
-    <header class="header">
+    <header class="header" lang="{lang}">
       <div class="logo">
         <ReutersLogo
           logoColour="var(--nav-accent)"
@@ -95,18 +96,20 @@
   .close-button {
     width: 40px;
     height: 40px;
-    margin-left: auto;
     display: inline-block;
     vertical-align: top;
     outline: none;
     border: none;
-    margin: 0;
+    margin: 0 0 0 auto;
     padding: 0;
     overflow: visible;
     background: transparent;
     color: inherit;
     font: inherit;
     line-height: normal;
+    &:enabled {
+      cursor: pointer;
+    }
 
     .button-container {
       border-radius: 8px;
@@ -149,10 +152,14 @@
       grid-template-columns: repeat(2, 1fr);
       grid-row-gap: 16px;
       @include spacing-single(grid-column-gap);
+      li {
+        margin: 0;
+      }
     }
 
     .section-link {
       font-size: 14px;
+      font-weight: 500;
     }
 
     .section-link,
@@ -165,6 +172,14 @@
       &:hover {
         text-decoration: underline;
       }
+    }
+    .subsection-link {
+      font-size: 16px;
+    }
+  }
+  .header[lang='ja'] ~ .section {
+    .section-link {
+      font-weight: 600;
     }
   }
 </style>

--- a/src/components/SiteHeader/NavBar/NavDropdown/MoreDropdown.svelte
+++ b/src/components/SiteHeader/NavBar/NavDropdown/MoreDropdown.svelte
@@ -1,11 +1,19 @@
 <script>
   import NavDropdown from './index.svelte';
-  import { normalizeUrl } from '../utils';
+  import { normalizeUrl, normalizeUrlJp } from '../utils';
 
   export let sections = [];
+  export let lang = 'en';
+  const normaliseUrl = lang === 'ja' ? normalizeUrlJp : normalizeUrl;
+  const labels = {
+    'Trending Stories': {
+      default: 'Trending Stories',
+      ja: '人気の記事',
+    },
+  };
 </script>
 
-<NavDropdown>
+<NavDropdown lang="{lang}" headingText="{labels['Trending Stories'][lang]}">
   <div class="more-sections">
     <div class="groupContainer">
       {#each sections as section}
@@ -13,14 +21,14 @@
           class="more-section-group"
           class:has-children="{section.children}"
         >
-          <a href="{normalizeUrl(section.url)}" class="section-link">
+          <a href="{normaliseUrl(section.url)}" class="section-link">
             {section.name}
           </a>
           {#if section.children}
             <ul class="subsections">
               {#each section.children as sub}
                 <li>
-                  <a class="subsection-link" href="{normalizeUrl(sub.url)}"
+                  <a class="subsection-link" href="{normaliseUrl(sub.url)}"
                     >{sub.name}</a
                   >
                 </li>

--- a/src/components/SiteHeader/NavBar/NavDropdown/SectionDropdown.svelte
+++ b/src/components/SiteHeader/NavBar/NavDropdown/SectionDropdown.svelte
@@ -1,10 +1,18 @@
 <script>
-  import { normalizeUrl } from '../utils';
+  import { normalizeUrl, normalizeUrlJp } from '../utils';
 
   import NavDropdown from './index.svelte';
 
   export let section = {};
   export let headingText;
+  export let lang = 'en';
+  const labels = {
+    Browse: {
+      default: (name) => `Browse ${name}`,
+      ja: (name) => `${name}を閲覧する`,
+    },
+  };
+  const normaliseUrl = lang === 'ja' ? normalizeUrlJp : normalizeUrl;
 
   $: splitCount =
     section.children && section.children.length > 7
@@ -12,10 +20,16 @@
       : 0;
 </script>
 
-<NavDropdown headingText="{headingText}">
-  <a href="{normalizeUrl(section.url)}">
-    <span class="heading">
-      Browse {section.name}
+<NavDropdown
+  headingText="{headingText}"
+  lang="{lang}"
+  hideHeadlines="{lang === 'ja' && section.id === '/pictures/'}"
+>
+  <a href="{normaliseUrl(section.url)}">
+    <span class="heading" lang="{lang}">
+      {labels.Browse[lang]
+        ? labels.Browse[lang](section.name)
+        : labels.Browse.default(section.name)}
     </span>
   </a>
   <div class="sections">
@@ -23,7 +37,7 @@
       <ul class="sections-group">
         {#each section.children.slice(0, splitCount) as sub}
           <li>
-            <a class="subsection-link" href="{normalizeUrl(sub.url)}">
+            <a class="subsection-link" href="{normaliseUrl(sub.url)}">
               {sub.name}
             </a>
           </li>
@@ -33,7 +47,7 @@
     <ul class="sections-group">
       {#each section.children.slice(splitCount) as sub}
         <li>
-          <a class="subsection-link" href="{normalizeUrl(sub.url)}">
+          <a class="subsection-link" href="{normaliseUrl(sub.url)}">
             {sub.name}
           </a>
         </li>
@@ -119,6 +133,9 @@
     &:hover {
       color: inherit;
       text-decoration: underline !important;
+    }
+    &[lang='ja'] {
+      font-weight: 600;
     }
   }
 

--- a/src/components/SiteHeader/NavBar/NavDropdown/StoryCard/index.svelte
+++ b/src/components/SiteHeader/NavBar/NavDropdown/StoryCard/index.svelte
@@ -1,57 +1,82 @@
 <script>
-  import { normalizeUrl } from '../../utils';
-  import { getTime } from './time';
+  import { normalizeUrl, normalizeUrlJp } from '../../utils';
+  import { getTime, dayjs } from './time';
+  import ja from 'dayjs/locale/ja';
 
   export let story;
   export let withSection = false;
+  export let lang = 'en';
+  if (lang === 'ja') {
+    dayjs.locale(ja);
+  }
+
+  const normaliseUrl = lang === 'ja' ? normalizeUrlJp : normalizeUrl;
+  const localeOptions = {
+    default: {
+      timeZone: false,
+      formatTime: 'h:mm A z',
+      formatDay: 'MMMM D, YYYY',
+    },
+    ja: {
+      timeZone: 'JST',
+      formatTime: 'Ah:mm z',
+      formatDay: 'YYYY年M月D日',
+    },
+  };
 
   $: thumbnail = story.thumbnail;
 </script>
 
-<div class="story-card">
-  <a href="{normalizeUrl(story.canonical_url)}">
-    <div class="story-text" class:has-thumbnail="{thumbnail}">
-      {#if withSection}
-        <a href="{normalizeUrl(story.primary_section.id)}">
-          <span class="label">{story.primary_section.name}</span>
-        </a>
-      {/if}
-      <span>{story.title}</span>
-      {#if !withSection}
-        <time datetime="{story.display_time}"
-          >{getTime(story.display_time)}</time
-        >
-      {/if}
-    </div>
-    {#if thumbnail}
-      <div class="thumbnail">
+<div class="story-card" lang="{lang}">
+  <div class="story-text" class:has-thumbnail="{thumbnail}">
+    {#if withSection && story.kicker}
+      <a href="{normaliseUrl(story.kicker.path)}">
+        <span class="label">{story.kicker.name}</span>
+      </a>
+    {/if}
+    <a href="{normaliseUrl(story.canonical_url)}">{story.title}</a>
+    {#if !withSection}
+      <time datetime="{story.display_time}"
+        >{getTime(
+          story.display_time,
+          localeOptions[lang] || localeOptions.default
+        )}</time
+      >
+    {/if}
+  </div>
+  {#if thumbnail}
+    <div class="thumbnail">
+      <a href="{normaliseUrl(story.canonical_url)}">
         <img
           src="{thumbnail.renditions.square['120w']}"
           alt="{thumbnail.alt_text}"
         />
-      </div>
-    {/if}
-  </a>
+      </a>
+    </div>
+  {/if}
 </div>
 
 <style lang="scss">
   @import '../../../../../scss/mixins';
 
-  .story-card a {
+  .story-card {
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
     color: var(--nav-primary, var(--tr-dark-grey));
-    text-decoration: none;
-
-    &:hover,
-    &:focus {
+    a {
       text-decoration: none;
-      .story-text span {
+      color: var(--nav-primary, var(--tr-dark-grey));
+      font-size: 16px;
+      font-weight: 500;
+      @include font-sans;
+      @media (min-width: 1300px) {
+        font-size: 18px;
+      }
+
+      &:hover,
+      &:focus {
         text-decoration: underline;
-        &.label {
-          text-decoration: none;
-        }
       }
     }
 
@@ -62,22 +87,12 @@
         width: calc(100% - 84px);
       }
 
-      span {
-        color: var(--nav-primary, var(--tr-dark-grey));
-        font-size: 16px;
-        font-weight: 500;
-        @include font-sans;
-        @media (min-width: 1300px) {
-          font-size: 18px;
-        }
-      }
-
       span.label {
         font-size: 14px;
         line-height: 1.1;
         margin-bottom: 8px;
         display: block;
-        font-weight: 200;
+        font-weight: 400;
       }
 
       time {
@@ -94,14 +109,44 @@
       width: 84px;
       height: 84px;
       flex: 0 0 84px;
-      border-radius: 8px;
       overflow: hidden;
-      border: 1px solid #ddd;
+      position: relative;
       img {
         object-fit: cover;
         width: 100%;
         height: 100%;
         margin: 0;
+      }
+      a {
+        &:after {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          pointer-events: none;
+          background: rgba(0, 0, 0, 0.2);
+          transition: opacity 0.15s ease;
+          opacity: 0;
+        }
+        &:hover,
+        &:focus {
+          &:after {
+            opacity: 1;
+          }
+        }
+      }
+    }
+
+    &[lang='ja'] {
+      .story-text {
+        a {
+          font-weight: 600;
+        }
+      }
+      time {
+        font-size: 11px;
       }
     }
   }

--- a/src/components/SiteHeader/NavBar/NavDropdown/StoryCard/time.js
+++ b/src/components/SiteHeader/NavBar/NavDropdown/StoryCard/time.js
@@ -57,14 +57,15 @@ const isSameDay = (dateFrom, dateTo) => {
   );
 };
 
-export const getTime = (datetime) => {
+export const getTime = (datetime, options) => {
   const publishTime = dayjs(datetime, { utc: true });
   const showRelativeTime = !olderThanHour(publishTime, Date.now());
   const showTime = isSameDay(publishTime, Date.now());
-  const timezone = getTimeZone(false);
+  const timezone = getTimeZone(options.timeZone);
   if (showRelativeTime) {
     return dayjs().to(publishTime);
   }
-  if (showTime) return dayjs(datetime).tz(timezone).format('h:mm A z');
-  return publishTime.format('MMMM D, YYYY');
+  if (showTime) return dayjs(datetime).tz(timezone).format(options.formatTime);
+  return publishTime.format(options.formatDay);
 };
+export { dayjs };

--- a/src/components/SiteHeader/NavBar/NavDropdown/index.svelte
+++ b/src/components/SiteHeader/NavBar/NavDropdown/index.svelte
@@ -7,19 +7,24 @@
   const activeSection = getContext('nav-active-section');
 
   export let headingText = 'Trending Stories';
+  export let lang = 'en';
+  export let hideHeadlines = false;
 
   let stories = [];
   let lastFetched = null;
+
+  const domain = lang === 'ja' ? 'jp' : 'www';
+  const website = lang === 'ja' ? 'reuters-japan' : 'reuters';
 
   afterUpdate(async () => {
     if (lastFetched === $activeSection) return;
     if ($activeSection === 'more') {
       await fetch(
-        'https://www.reuters.com/pf/api/v3/content/fetch/articles-by-trends-v1?' +
+        `https://${domain}.reuters.com/pf/api/v3/content/fetch/articles-by-trends-v1?` +
           new URLSearchParams({
             query: JSON.stringify({
               size: 4,
-              website: 'reuters',
+              website,
             }),
           })
       )
@@ -30,12 +35,12 @@
         });
     } else {
       await fetch(
-        'https://www.reuters.com/pf/api/v3/content/fetch/recent-stories-by-sections-v1?' +
+        `https://${domain}.reuters.com/pf/api/v3/content/fetch/recent-stories-by-sections-v1?` +
           new URLSearchParams({
             query: JSON.stringify({
               section_ids: $activeSection,
               size: 4,
-              website: 'reuters',
+              website,
             }),
           })
       )
@@ -56,27 +61,30 @@
           <slot />
         </div>
       </div>
-      <div class="stories-container">
-        <div class="inner">
-          {#if stories.length > 0}
-            <span class="latest">{headingText}</span>
-            <ul class="story-list">
-              {#each stories as story}
-                <li class="story-item">
-                  <StoryCard
-                    story="{story}"
-                    withSection="{$activeSection === 'more'}"
-                  />
-                </li>
-              {/each}
-            </ul>
-          {:else}
-            <div class="spinner">
-              <Spinner />
-            </div>
-          {/if}
+      {#if stories && !hideHeadlines}
+        <div class="stories-container">
+          <div class="inner">
+            {#if stories.length > 0}
+              <span class="latest">{headingText}</span>
+              <ul class="story-list">
+                {#each stories as story}
+                  <li class="story-item">
+                    <StoryCard
+                      story="{story}"
+                      withSection="{$activeSection === 'more'}"
+                      lang="{lang}"
+                    />
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <div class="spinner">
+                <Spinner />
+              </div>
+            {/if}
+          </div>
         </div>
-      </div>
+      {/if}
     </div>
   </div>
 </div>

--- a/src/components/SiteHeader/NavBar/index.svelte
+++ b/src/components/SiteHeader/NavBar/index.svelte
@@ -2,12 +2,21 @@
   import DownArrow from './DownArrow.svelte';
   import SectionDropdown from './NavDropdown/SectionDropdown.svelte';
   import MoreDropdown from './NavDropdown/MoreDropdown.svelte';
-  import { normalizeUrl } from './utils/index';
+  import { normalizeUrl, normalizeUrlJp } from './utils/index';
   import { getContext } from 'svelte';
 
   export let sections = [];
+  export let lang = 'en';
 
   const activeSection = getContext('nav-active-section');
+  const normaliseUrl = lang === 'ja' ? normalizeUrlJp : normalizeUrl;
+  const labels = {
+    More: { default: 'More ', ja: 'さらに見る' },
+    'Latest in': {
+      default: (name) => `Latest in ${name}`,
+      ja: (name) => `${name}の記事を見る`,
+    },
+  };
 
   let windowWidth = 1200;
 
@@ -26,7 +35,7 @@
 
 <svelte:window bind:innerWidth="{windowWidth}" />
 
-<div class="nav-bar">
+<div class="nav-bar" lang="{lang}">
   <nav aria-label="Main navigation">
     <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
     <ul class="nav-list">
@@ -61,7 +70,7 @@
               class="nav-button link"
               class:open="{section.id === $activeSection}"
             >
-              <a href="{normalizeUrl(section.url)}">
+              <a href="{normaliseUrl(section.url)}">
                 {section.name}
               </a>
               <button class="button">
@@ -71,14 +80,17 @@
             {#if $activeSection === section.id}
               <SectionDropdown
                 section="{section}"
-                headingText="{`Latest in ${section.name}`}"
+                headingText="{labels['Latest in'][lang]
+                  ? labels['Latest in'][lang](section.name)
+                  : labels['Latest in'].default(section.name)}"
+                lang="{lang}"
               />
             {/if}
           </li>
         {:else}
           <li class="nav-item category link">
             <div class="nav-button link">
-              <a href="{normalizeUrl(section.url)}">
+              <a href="{normaliseUrl(section.url)}">
                 {section.name}
               </a>
             </div>
@@ -112,11 +124,15 @@
           class:open="{$activeSection === 'more'}"
         >
           <button class="button">
-            <span>More <DownArrow rotate="{$activeSection === 'more'}" /></span>
+            <span
+              >{labels.More[lang] || labels.More.default}<DownArrow
+                rotate="{$activeSection === 'more'}"
+              /></span
+            >
           </button>
         </div>
         {#if $activeSection === 'more'}
-          <MoreDropdown sections="{hiddenSections}" />
+          <MoreDropdown sections="{hiddenSections}" lang="{lang}" />
         {/if}
       </li>
     </ul>
@@ -261,6 +277,17 @@
       &:nth-child(-n + 7) {
         display: inline-flex;
       }
+    }
+  }
+
+  .nav-bar[lang='ja'] {
+    .nav-item,
+    .button {
+      font-weight: 600;
+      font-size: 14px;
+    }
+    .button {
+      font-size: 14px;
     }
   }
 </style>

--- a/src/components/SiteHeader/NavBar/utils/index.js
+++ b/src/components/SiteHeader/NavBar/utils/index.js
@@ -1,2 +1,5 @@
 export const normalizeUrl = (url) =>
   /^http/.test(url) ? url : `https://www.reuters.com${url}`;
+
+export const normalizeUrlJp = (url) =>
+  /^http/.test(url) ? url : `https://jp.reuters.com${url}`;

--- a/src/components/SiteHeader/SiteHeader.stories.svelte
+++ b/src/components/SiteHeader/SiteHeader.stories.svelte
@@ -5,6 +5,8 @@
   import componentDocs from './stories/docs/component.md?raw';
   // @ts-ignore
   import darkThemeDocs from './stories/docs/darkTheme.md?raw';
+  // @ts-ignore
+  import japanese from './stories/docs/japanese.md?raw';
 
   import SiteHeader from './SiteHeader.svelte';
   import Theme from '../Theme/Theme.svelte';
@@ -37,6 +39,12 @@
     <Theme base="dark">
       <SiteHeader />
     </Theme>
+  </div>
+</Story>
+
+<Story name="Japanese" {...withStoryDocs(japanese)}>
+  <div>
+    <SiteHeader lang="ja" />
   </div>
 </Story>
 

--- a/src/components/SiteHeader/SiteHeader.svelte
+++ b/src/components/SiteHeader/SiteHeader.svelte
@@ -3,6 +3,7 @@
   import ReutersLogo from '../ReutersLogo/ReutersLogo.svelte';
   import NavBar from './NavBar/index.svelte';
   import starterData from './data.json';
+  import starterDataJp from './data-jp.json';
   import { onMount, setContext } from 'svelte';
   import { writable } from 'svelte/store';
   import MenuIcon from './svgs/Menu.svelte';
@@ -10,7 +11,15 @@
 
   setContext('nav-active-section', writable(null));
 
-  let data = starterData;
+  export let lang = 'en';
+
+  let data = lang === 'ja' ? starterDataJp : starterData;
+  const domain = lang === 'ja' ? 'jp' : 'www';
+  const website = lang === 'ja' ? 'reuters-japan' : 'reuters';
+  const font =
+    lang === 'ja'
+      ? '-apple-system, "Hiragino Kaku Gothic Pro", "Meiryo", "MS Pgothic", helvetica, arial, sans-serif'
+      : 'Knowledge';
 
   $: sections = data[0].sections;
 
@@ -23,9 +32,9 @@
     }
     try {
       const response = await fetch(
-        'https://www.reuters.com/site-api/header/?' +
+        `https://${domain}.reuters.com/site-api/header/?` +
           new URLSearchParams({
-            _website: 'reuters',
+            _website: website,
             outputType: 'json',
           })
       );
@@ -46,8 +55,9 @@
     --nav-rules: var(--theme-colour-brand-rules, #d0d0d0);
     --nav-accent: var(--theme-colour-brand-logo, #fa6400);
     --nav-shadow: 0 1px 4px 2px var(--theme-colour-brand-shadow, rgb(255 255 255 / 10%));
-    --theme-font-family-sans-serif: Knowledge, sans-serif;
+    --theme-font-family-sans-serif: ${font}, sans-serif;
   `}"
+  lang="{lang}"
 >
   <div class="nav-container show-nav">
     <div class="scroll-container">
@@ -55,7 +65,7 @@
         <div class="main-bar">
           <div class="logo-container">
             <div class="logo">
-              <a href="https://www.reuters.com">
+              <a href="https://{domain}.reuters.com">
                 <ReutersLogo
                   logoColour="var(--nav-accent)"
                   textColour="var(--nav-primary)"
@@ -63,7 +73,7 @@
               </a>
             </div>
           </div>
-          <NavBar sections="{sections}" />
+          <NavBar sections="{sections}" lang="{lang}" />
           <!-- Space takes the place of the MyViewMenu, NavSearchBar & Account components... -->
           <div class="spacer-container">
             <div class="spacer"></div>
@@ -98,6 +108,7 @@
     isMobileMenuOpen = false;
   }}"
   data="{data[0]}"
+  lang="{lang}"
 />
 
 <style lang="scss">
@@ -233,6 +244,9 @@
       color: inherit;
       font: inherit;
       line-height: normal;
+      &:enabled {
+        cursor: pointer;
+      }
 
       .button-container {
         border-radius: 8px;

--- a/src/components/SiteHeader/data-jp.json
+++ b/src/components/SiteHeader/data-jp.json
@@ -1,0 +1,304 @@
+[
+    {
+        "sections": [
+            {
+                "id": "/world/",
+                "url": "/world/",
+                "name": "ワールド",
+                "type": "section",
+                "children": [
+                    {
+                        "id": "/world/japan/",
+                        "url": "/world/japan/",
+                        "name": "国内"
+                    },
+                    {
+                        "id": "/world/us/",
+                        "url": "/world/us/",
+                        "name": "米国"
+                    },
+                    {
+                        "id": "/world/china/",
+                        "url": "/world/china/",
+                        "name": "中国"
+                    },
+                    {
+                        "id": "/world/europe/",
+                        "url": "/world/europe/",
+                        "name": "欧州"
+                    },
+                    {
+                        "id": "/world/ukraine/",
+                        "url": "/world/ukraine/",
+                        "name": "ウクライナ情勢"
+                    },
+                    {
+                        "id": "/world/russia/",
+                        "url": "/world/russia/",
+                        "name": "ロシア"
+                    },
+                    {
+                        "id": "/world/north-korea/",
+                        "url": "/world/north-korea/",
+                        "name": "北朝鮮"
+                    },
+                    {
+                        "id": "/world/korea/",
+                        "url": "/world/korea/",
+                        "name": "韓国"
+                    },
+                    {
+                        "id": "/world/mideast/",
+                        "url": "/world/mideast/",
+                        "name": "中東・アフリカ"
+                    },
+                    {
+                        "id": "/world/security/",
+                        "url": "/world/security/",
+                        "name": "特集 安全保障問題"
+                    },
+                    {
+                        "id": "/world/us-politics/",
+                        "url": "/world/us-politics/",
+                        "name": "バイデン政権特集"
+                    },
+                    {
+                        "id": "/world/environment/",
+                        "url": "/world/environment/",
+                        "name": "自然災害"
+                    },
+                    {
+                        "id": "/world/interview/",
+                        "url": "/world/interview/",
+                        "name": "インタビュー"
+                    }
+                ]
+            },
+            {
+                "id": "/markets/",
+                "url": "/markets/",
+                "name": "マーケット",
+                "type": "section",
+                "children": [
+                    {
+                        "id": "/markets/currencies/",
+                        "url": "/markets/currencies/",
+                        "name": "外国為替"
+                    },
+                    {
+                        "id": "/markets/bonds/",
+                        "url": "/markets/bonds/",
+                        "name": "金利・国債"
+                    },
+                    {
+                        "id": "/markets/global-markets/",
+                        "url": "/markets/global-markets/",
+                        "name": "株式市場"
+                    },
+                    {
+                        "id": "/markets/oil/",
+                        "url": "/markets/oil/",
+                        "name": "原油・エネルギー"
+                    },
+                    {
+                        "id": "/markets/commodities/",
+                        "url": "/markets/commodities/",
+                        "name": "商品先物"
+                    },
+                    {
+                        "id": "/markets/cryptocurrency/",
+                        "url": "/markets/cryptocurrency/",
+                        "name": "特集 仮想通貨"
+                    },
+                    {
+                        "id": "/markets/world-indices/",
+                        "url": "/markets/world-indices/",
+                        "name": "各国の株式指数"
+                    },
+                    {
+                        "id": "/markets/europe/",
+                        "url": "/markets/europe/",
+                        "name": "欧州マーケット"
+                    },
+                    {
+                        "id": "/markets/us/",
+                        "url": "/markets/us/",
+                        "name": "アメリカマーケット"
+                    },
+                    {
+                        "id": "/markets/asia/",
+                        "url": "/markets/asia/",
+                        "name": "アジアマーケット"
+                    },
+                    {
+                        "id": "/markets/japan/",
+                        "url": "/markets/japan/",
+                        "name": "国内マーケット"
+                    }
+                ]
+            },
+            {
+                "id": "/economy/",
+                "url": "/economy/",
+                "name": "経済",
+                "type": "section",
+                "children": [
+                    {
+                        "id": "/economy/federal-reserve-board/",
+                        "url": "/economy/federal-reserve-board/",
+                        "name": "米ＦＲＢ特集"
+                    },
+                    {
+                        "id": "/economy/bank-of-japan/",
+                        "url": "/economy/bank-of-japan/",
+                        "name": "日銀特集"
+                    },
+                    {
+                        "id": "/economy/japan-politics/",
+                        "url": "/economy/japan-politics/",
+                        "name": "政局の行方"
+                    },
+                    {
+                        "id": "/economy/industry/",
+                        "url": "/economy/industry/",
+                        "name": "企業・産業"
+                    }
+                ]
+            },
+            {
+                "id": "/business/",
+                "url": "/business/",
+                "name": "ビジネス",
+                "type": "section",
+                "children": [
+                    {
+                        "id": "/business/technology/",
+                        "url": "/business/technology/",
+                        "name": "テクノロジー"
+                    },
+                    {
+                        "id": "/business/autos/",
+                        "url": "/business/autos/",
+                        "name": "自動車産業の未来"
+                    },
+                    {
+                        "id": "/business/sdgs/",
+                        "url": "/business/sdgs/",
+                        "name": "SDGsとビジネス"
+                    },
+                    {
+                        "id": "/business/ma/",
+                        "url": "/business/ma/",
+                        "name": "金融・Ｍ＆Ａ"
+                    }
+                ]
+            },
+            {
+                "id": "/opinion/",
+                "url": "/opinion/",
+                "name": "オピニオン",
+                "type": "section",
+                "children": [
+                    {
+                        "id": "/opinion/forex-forum/",
+                        "url": "/opinion/forex-forum/",
+                        "name": "外国為替フォーラム"
+                    },
+                    {
+                        "id": "/opinion/breakingviews/",
+                        "url": "/opinion/breakingviews/",
+                        "name": "Breakingviews"
+                    }
+                ]
+            },
+            {
+                "id": "/life/",
+                "url": "/life/",
+                "name": "ライフ",
+                "type": "section",
+                "children": [
+                    {
+                        "id": "/life/sports/",
+                        "url": "/life/sports/",
+                        "name": "スポーツ"
+                    },
+                    {
+                        "id": "/life/entertainment/",
+                        "url": "/life/entertainment/",
+                        "name": "エンタテインメント"
+                    }
+                ]
+            },
+            {
+                "id": "/pictures/",
+                "url": "/pictures/",
+                "name": "写真",
+                "type": "section",
+                "children": [
+                    {
+                        "id": "/pictures/wider-image/",
+                        "url": "/pictures/wider-image/",
+                        "name": "Wider Image"
+                    }
+                ]
+            },
+            {
+                "id": "/video/",
+                "url": "/video/",
+                "name": "ビデオ",
+                "type": "section",
+                "children": [
+                    {
+                        "id": "/video/in-depth/",
+                        "url": "/video/in-depth/",
+                        "name": "日本語のビデオ"
+                    },
+                    {
+                        "id": "/video/entertainment/",
+                        "url": "/video/entertainment/",
+                        "name": "エンタテインメント"
+                    },
+                    {
+                        "id": "/video/oddly-enough/",
+                        "url": "/video/oddly-enough/",
+                        "name": "ライフ"
+                    },
+                    {
+                        "id": "/video/business/",
+                        "url": "/video/business/",
+                        "name": "ビジネス"
+                    },
+                    {
+                        "id": "/video/most-popular/",
+                        "url": "/video/most-popular/",
+                        "name": "最も見られているビデオ"
+                    },
+                    {
+                        "id": "/video/sports/",
+                        "url": "/video/sports/",
+                        "name": "スポーツ"
+                    },
+                    {
+                        "id": "/video/technology/",
+                        "url": "/video/technology/",
+                        "name": "テクノロジー"
+                    },
+                    {
+                        "id": "/video/environment/",
+                        "url": "/video/environment/",
+                        "name": "自然災害"
+                    }
+                ]
+            }
+        ],
+        "home_url": "/",
+        "search_url": "/site-search/",
+        "sign_in_url": "",
+        "sign_up_url": "",
+        "subscribe_url": "",
+        "my_account_url": "",
+        "my_view_url": "/myview/all",
+        "following_url": "/myview/following-feed",
+        "saved_url": "/myview/saved"
+    }
+]

--- a/src/components/SiteHeader/stories/docs/component.md
+++ b/src/components/SiteHeader/stories/docs/component.md
@@ -1,7 +1,5 @@
 Reuters dotcom site header, ported from [Raptor UI components](https://github.com/tr/rcom-arc_raptor-ui/tree/develop/packages/rcom-raptor-ui_common/src/components/site-header).
 
-(Go to the "[Canvas](./?path=/story/components-siteheader--default)" tab to see this component better. It'll look a bit broken below... but it's NOT!)
-
 > **Note:** In the Graphics Kit, you can find this component in `pages/+page.svelte`. Customise it there for the default page.
 
 ```svelte

--- a/src/components/SiteHeader/stories/docs/japanese.md
+++ b/src/components/SiteHeader/stories/docs/japanese.md
@@ -1,0 +1,9 @@
+lang="ja"を設定することで日本語のヘッダに変更することができます。
+
+```svelte
+<script>
+  import { SiteHeader } from '@reuters-graphics/graphics-components';
+</script>
+
+<SiteHeader lang="ja" />
+```


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix
- [x] New component/feature
- [ ] Documentation update
- [ ] Other

### Description

Modified SiteHeader and SiteFooter components for Japanese. 
Setting <SiteHeader lang="ja" /> <SiteFooter lang="ja" /> enables switching them to local language service.
I also changed SiteHeader/NavBar/NavDropdown/StoryCard/index.svelte #32-34 {#if withSection ... because it causes an error when you mouseover to 'More' in the main menu.

### Before submitting, please check that you've

- [x] Read our [contributing guide](https://github.com/reuters-graphics/graphics-components/blob/master/CONTRIBUTING.md) at some point
- [ ] Formatted you code correctly (i.e., prettier cleaned it up)
- [ ] Documented any new components or features
- [ ] Tagged an editor to review
