### PR TITLE
Break out Select element from Table

### DIFF
--- a/src/components/Select/Select.stories.svelte
+++ b/src/components/Select/Select.stories.svelte
@@ -1,0 +1,65 @@
+<script>
+  import { Meta, Template, Story } from '@storybook/addon-svelte-csf';
+
+  // Don't lose the "?raw" in markdown imports!
+  // @ts-ignore
+  import componentDocs from './stories/docs/component.md?raw';
+  // @ts-ignore
+  import labelDocs from './stories/docs/label.md?raw';
+  // @ts-ignore
+  import defaultDocs from './stories/docs/default.md?raw';
+
+  import Select from './Select.svelte';
+
+  import { withComponentDocs, withStoryDocs } from '$docs/utils/withParams.js';
+
+  const optionList = [
+    {
+      text: 'Red',
+      value: 'r',
+    },
+    {
+      text: 'Blue',
+      value: 'b',
+    },
+    {
+      text: 'Green',
+      value: 'g',
+    },
+  ];
+
+  const metaProps = {
+    ...withComponentDocs(componentDocs),
+  };
+</script>
+
+<Meta title="Components/Select" component="{Select}" {...metaProps} />
+
+<Template let:args>
+  <Select {...args} />
+</Template>
+
+<Story
+  name="Default"
+  args="{{
+    options: optionList,
+  }}"
+/>
+
+<Story
+  name="Label"
+  {...withStoryDocs(labelDocs)}
+  args="{{
+    label: 'Pick a color',
+    options: optionList,
+  }}"
+/>
+
+<Story
+  name="Selected"
+  {...withStoryDocs(defaultDocs)}
+  args="{{
+    selected: 'g',
+    options: optionList,
+  }}"
+/>

--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -2,11 +2,32 @@
   import { createEventDispatcher } from 'svelte';
   import type { Option } from '../@types/global';
 
+  /** Add an ID to target with SCSS.
+   * @type {string}
+   */
+  export let id: string = '';
+
+  /** Add a class to target with SCSS.
+   * @type {string}
+   */
+  export let cls: string = '';
+
+  /** Add a name to the <select> element.
+   * @type {string}
+   */
+  export let name: string = 'select--input';
+
   /**
    * The label that appears above the select input.
    * @type {string}
    */
   export let label: string = '';
+
+  /**
+   * The selected value
+   * @type {string}
+   */
+  export let selected: string | null = null;
 
   /**
    * The label that appears above the select input.
@@ -22,15 +43,16 @@
   }
 </script>
 
-<div class="select">
+<div id="{id}" class="select {cls}">
   {#if label}
     <label class="body-caption block" for="select--input">{label}</label>
   {/if}
   <select
     class="select--input body-caption fpx-2"
-    name="select--input"
+    name="{name}"
     id="select--input"
     on:input="{input}"
+    bind:value="{selected}"
   >
     {#each options as obj}
       <option value="{obj.value}">{obj.text}</option>

--- a/src/components/Select/stories/docs/component.md
+++ b/src/components/Select/stories/docs/component.md
@@ -1,0 +1,27 @@
+Invite users to pick an option from a predefined list.
+
+---
+
+```html
+<script>
+  import { Select } from '@reuters-graphics/graphics-components';
+
+  // Options must be provided as a list of objects with `text` and `value` keys.
+  const optionList = [
+    {
+      text: 'Red', // The `text` key is what is displayed to the user.
+      value: 'r', // The `value` key is what is passed to the `selected` property.
+    },
+    {
+      text: 'Blue',
+      value: 'b',
+    },
+    {
+      text: 'Green',
+      value: 'g',
+    },
+  ];
+</script>
+
+<select options="{optionList}" />
+```

--- a/src/components/Select/stories/docs/default.md
+++ b/src/components/Select/stories/docs/default.md
@@ -1,0 +1,24 @@
+This argument lets you set the option that is `selected` by default. It expects that you pass the `value` of the option you want.
+
+```html
+<script>
+  import { Select } from '@reuters-graphics/graphics-components';
+
+  const optionList = [
+    {
+      text: 'Red',
+      value: 'r',
+    },
+    {
+      text: 'Blue',
+      value: 'b',
+    },
+    {
+      text: 'Green',
+      value: 'g',
+    },
+  ];
+</script>
+
+<select selected="{'g'}" options="{optionList}" />
+```

--- a/src/components/Select/stories/docs/label.md
+++ b/src/components/Select/stories/docs/label.md
@@ -1,0 +1,24 @@
+You have the option of including a `label` argument that will appear above the pulldown menu.
+
+```html
+<script>
+  import { Select } from '@reuters-graphics/graphics-components';
+
+  const optionList = [
+    {
+      text: 'Red',
+      value: 'r',
+    },
+    {
+      text: 'Blue',
+      value: 'b',
+    },
+    {
+      text: 'Green',
+      value: 'g',
+    },
+  ];
+</script>
+
+<select label="{'Pick a color'}" options="{optionList}" />
+```

--- a/src/components/Table/Table.svelte
+++ b/src/components/Table/Table.svelte
@@ -137,7 +137,7 @@
   import Block from '../Block/Block.svelte';
   import Pagination from './Pagination.svelte';
   import SearchInput from '../SearchInput/SearchInput.svelte';
-  import Select from './Select.svelte';
+  import Select from '../Select/Select.svelte';
   import SortArrow from './SortArrow.svelte';
   import { filterArray, paginateArray, getOptions } from './utils.js';
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export { default as resizeObserver } from './actions/resizeObserver/index.js';
 // Components
 export {
   default as Analytics,
-  registerPageview,
+  registerPageview
 } from './components/Analytics/Analytics.svelte';
 export { default as Article } from './components/Article/Article.svelte';
 export { default as BeforeAfter } from './components/BeforeAfter/BeforeAfter.svelte';
@@ -32,6 +32,7 @@ export { default as ReutersGraphicsLogo } from './components/ReutersGraphicsLogo
 export { default as ReutersLogo } from './components/ReutersLogo/ReutersLogo.svelte';
 export { default as Scroller } from './components/Scroller/Scroller.svelte';
 export { default as SearchInput } from './components/SearchInput/SearchInput.svelte';
+export { default as Select } from './components/Select/Select.svelte';
 export { default as SEO } from './components/SEO/SEO.svelte';
 export { default as Sharer } from './components/Sharer/Sharer.svelte';
 export { default as SimpleTimeline } from './components/SimpleTimeline/SimpleTimeline.svelte';
@@ -43,7 +44,7 @@ export { default as Table } from './components/Table/Table.svelte';
 export {
   default as Theme,
   // @ts-ignore
-  themes,
+  themes
 } from './components/Theme/Theme.svelte';
 export { default as ToolsHeader } from './components/ToolsHeader/ToolsHeader.svelte';
 export { default as Video } from './components/Video/Video.svelte';


### PR DESCRIPTION
This PR replaces #84 

### What's in this pull request

- [ ] Bug fix
- [x] New component/feature
- [ ] Documentation update
- [ ] Other

### Description

This crowbars the Select component created for the Table out so it can be used on its own.

### Before submitting, please check that you've

- [x] Read our [contributing guide](https://github.com/reuters-graphics/graphics-components/blob/master/CONTRIBUTING.md) at some point
- [x] Formatted you code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Tagged an editor to review
