### PR TITLE
Change script load flow to make it identical to initial implementation

### DIFF
--- a/src/components/AdSlot/AdScripts.svelte
+++ b/src/components/AdSlot/AdScripts.svelte
@@ -8,8 +8,10 @@
     window.graphicsAdQueue = window.graphicsAdQueue || [];
     loadScript(
       'https://graphics.thomsonreuters.com/cdn/js/bootstrap.static.js',
-      loadBootstrap
+      { onload: loadBootstrap, async: false }
     );
+    // Load Freestar script
+    loadScript('https://a.pub.network/reuters-com/pubfig.min.js');
   });
 </script>
 

--- a/src/components/AdSlot/adScripts/bootstrap.ts
+++ b/src/components/AdSlot/adScripts/bootstrap.ts
@@ -1,6 +1,5 @@
 import getParameterByName from './getParameterByName';
 import Ias from './ias';
-import { loadScript } from './loadScript';
 
 const ONETRUST_LOGS = 'ot_logs';
 const ONETRUST_GEOLOCATION_MOCK = 'ot_geolocation_mock';
@@ -42,9 +41,6 @@ export const loadBootstrap = () => {
   );
 
   (<any>window).bootstrap.getResults((result) => {
-    // Load Freestar script
-    loadScript('https://a.pub.network/reuters-com/pubfig.min.js');
-
     // Set GAM
     window.googletag = (<any>window).googletag || { cmd: [] };
     window.googletag.cmd.push(() => {

--- a/src/components/AdSlot/adScripts/loadScript.ts
+++ b/src/components/AdSlot/adScripts/loadScript.ts
@@ -1,6 +1,14 @@
-export const loadScript = (src: string, onload?: () => void) => {
+interface attributesInterface {
+  onload?: () => void,
+  async?: boolean
+}
+
+export const loadScript = (src: string, attributes?: attributesInterface) => {
+  const { onload, async = true } = attributes || {};
+
   const script = document.createElement('script');
   script.addEventListener('load', onload);
+  script.async = async;
   script.src = src;
   document.head.append(script);
 };


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix
- [ ] New component/feature
- [ ] Documentation update
- [ ] Other

### Description

Change script load flow to make it identical to initial implementation:
- Load OneTrust's script synchronously
- Then load pubfig.min.js

### Before submitting, please check that you've

- [ ] Read our [contributing guide](https://github.com/reuters-graphics/graphics-components/blob/master/CONTRIBUTING.md) at some point
- [ ] Formatted you code correctly (i.e., prettier cleaned it up)
- [ ] Documented any new components or features
- [ ] Tagged an editor to review
