### PR TITLE
AB#668856 DONE: Install bootstrap package via npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@reuters-graphics/graphics-components",
-  "version": "1.0.30",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reuters-graphics/graphics-components",
-      "version": "1.0.30",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/free-regular-svg-icons": "^5.15.3",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@splidejs/svelte-splide": "^0.2.9",
         "@sveltejs/svelte-scroller": "^2.0.7",
+        "@tr/rcom-bootstrap": "1.1.2",
         "dayjs": "^1.11.3",
         "journalize": "^2.6.0",
         "lodash-es": "^4.17.21",
@@ -5960,6 +5961,12 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tr/rcom-bootstrap": {
+      "version": "1.1.2",
+      "resolved": "https://npm.pkg.github.com/download/@tr/rcom-bootstrap/1.1.2/77286f44af79cd485de46273712e53e65ce09071",
+      "integrity": "sha512-3SQhFynpDirJVOhvJK0XrJosuNxJ2+0oDEuLrhlwiXqvApFQh8H3MDBrchXj1pH8/rLSG8CN8s31aTDv6BiF1Q==",
+      "license": "UNLICENSED"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "vite": "^5.4.2"
   },
   "dependencies": {
+    "@tr/rcom-bootstrap": "1.1.2",
     "@fortawesome/free-regular-svg-icons": "^5.15.3",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@splidejs/svelte-splide": "^0.2.9",

--- a/src/components/AdSlot/AdScripts.svelte
+++ b/src/components/AdSlot/AdScripts.svelte
@@ -6,10 +6,7 @@
 
   onMount(() => {
     window.graphicsAdQueue = window.graphicsAdQueue || [];
-    loadScript(
-      'https://graphics.thomsonreuters.com/cdn/js/bootstrap.static.js',
-      { onload: loadBootstrap, async: false }
-    );
+    loadBootstrap;
     // Load Freestar script
     loadScript('https://a.pub.network/reuters-com/pubfig.min.js');
   });

--- a/src/components/AdSlot/AdScripts.svelte
+++ b/src/components/AdSlot/AdScripts.svelte
@@ -6,7 +6,7 @@
 
   onMount(() => {
     window.graphicsAdQueue = window.graphicsAdQueue || [];
-    loadBootstrap;
+    loadBootstrap();
     // Load Freestar script
     loadScript('https://a.pub.network/reuters-com/pubfig.min.js');
   });

--- a/src/components/AdSlot/adScripts/bootstrap.ts
+++ b/src/components/AdSlot/adScripts/bootstrap.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import '@tr/rcom-bootstrap/build/bootstrap.static.js';
 import getParameterByName from './getParameterByName';
 import Ias from './ias';
 


### PR DESCRIPTION
### What's in this pull request

Tell us what this PR does or link to any related issues that describe the goal here.
https://dev.azure.com/tr-reuters/Reuters-Engineering/_workitems/edit/668856

As the bootstrap package is a private package it requires the modification in .npmrc file to include PAT there.

```
@tr:registry=https://npm.pkg.github.com/tr

//npm.pkg.github.com/:_authToken=ghp_your-token
email=example@thomsonreuters.com
always-auth=true
```

### Before submitting, please check that you've ...

- [x] Read our [contributing guide](https://github.com/reuters-graphics/graphics-components/blob/master/CONTRIBUTING.md)
- [ ] Documented any new components or features
- [ ] Tagged an editor to review this PR
