### PR TITLE
Quick snippet prop cleanup in Byline

### DIFF
--- a/src/components/Byline/Byline.svelte
+++ b/src/components/Byline/Byline.svelte
@@ -65,9 +65,9 @@
       const authorSlug = slugify(author.trim(), { lower: true });
       return `https://www.reuters.com/authors/${authorSlug}/`;
     },
-    byline = null,
-    published = null,
-    updated = null,
+    byline,
+    published,
+    updated,
   }: Props = $props();
 
   let alignmentClass = $derived(align === 'left' ? 'text-left' : 'text-center');


### PR DESCRIPTION
Optional snippet props were unnecessarily defaulting to `null`, so got rid of that. they should just be undefined if they're not passed.