### PR TITLE
Svelte 5 migration cleanup

### DIFF
--- a/src/components/Table/Table.svelte
+++ b/src/components/Table/Table.svelte
@@ -285,8 +285,8 @@
       <Pagination
         bind:pageNumber
         bind:pageSize
-        bind:pageLength={currentPageData.length}
-        bind:n={sortedData.length}
+        pageLength={currentPageData.length}
+        n={sortedData.length}
       />{/if}
   </div>
 </Block>

--- a/src/components/Table/components/Pagination.svelte
+++ b/src/components/Table/components/Pagination.svelte
@@ -25,8 +25,8 @@
   let {
     pageNumber = $bindable(1),
     pageSize = $bindable(25),
-    pageLength = $bindable(1),
-    n = $bindable(1),
+    pageLength = 1,
+    n = 1,
   }: Props = $props();
 
   let minRow = $derived(pageNumber * pageSize - pageSize + 1);


### PR DESCRIPTION
### What's in this pull request

Some props that shouldn't be bindable were set up bindable in `Table.svelte`, which was throwing warnings. I've turned them into regular props and tested them to confirm that the table still work as it should.