### PR TITLE
Allows `step.background` to be undefined 

### DIFF
--- a/.changeset/grumpy-lines-heal.md
+++ b/.changeset/grumpy-lines-heal.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+Allows step.background to be undefined

--- a/src/components/@types/global.ts
+++ b/src/components/@types/global.ts
@@ -31,7 +31,7 @@ export interface ScrollerStep {
   /**
    * A background component
    */
-  background: Component;
+  background: Component | undefined;
   /**
    * Optional props for background component
    */


### PR DESCRIPTION
### What's in this pull request

Allows `step.background` to be undefined to account for cases where the entire scroller uses only one background, not one background for each step.