### PR TITLE
Fix prop type on Theme

### DIFF
--- a/src/components/Theme/@types/component.ts
+++ b/src/components/Theme/@types/component.ts
@@ -50,7 +50,7 @@ export interface Theme {
 export interface CustomProperties {
   [key: string]: string | number | boolean | object | [];
 }
- 
+
 export interface CustomTheme {
   colour?: Partial<Colour>;
   font?: Partial<CustomFont>;

--- a/src/components/Theme/@types/component.ts
+++ b/src/components/Theme/@types/component.ts
@@ -47,8 +47,12 @@ export interface Theme {
   font: Font;
 }
 
+export interface CustomProperties {
+  [key: string]: string | number | boolean | object | [];
+}
+ 
 export interface CustomTheme {
   colour?: Partial<Colour>;
   font?: Partial<CustomFont>;
-  [key: string]: unknown;
+  customProperties?: CustomProperties;
 }

--- a/src/components/Theme/@types/component.ts
+++ b/src/components/Theme/@types/component.ts
@@ -50,5 +50,5 @@ export interface Theme {
 export interface CustomTheme {
   colour?: Partial<Colour>;
   font?: Partial<CustomFont>;
-  [customProperty: string]: unknown;
+  [key: string]: unknown;
 }

--- a/src/components/Theme/@types/component.ts
+++ b/src/components/Theme/@types/component.ts
@@ -50,5 +50,5 @@ export interface Theme {
 export interface CustomTheme {
   colour?: Partial<Colour>;
   font?: Partial<CustomFont>;
-  customProperties?: unknown;
+  [customProperty: string]: unknown;
 }

--- a/src/components/Theme/Theme.svelte
+++ b/src/components/Theme/Theme.svelte
@@ -14,7 +14,7 @@
   import mergeThemes from './utils/merge.js';
 
   // Types
-  import type { CustomTheme } from './@types/component';
+  import type { CustomTheme, Theme } from './@types/component';
   import type { Snippet } from 'svelte';
   type Base = 'light' | 'dark';
 
@@ -22,7 +22,7 @@
     /** Custom theme object. Can be a partial theme with just
      * what you want to change.
      */
-    theme?: CustomTheme;
+    theme?: CustomTheme | Theme;
     /**
      * Base theme is one of `light` or `dark` and will be merged
      * with your custom theme to fill in any values you don't


### PR DESCRIPTION
### What's in this PR
Fixes https://github.com/reuters-graphics/graphics-components/issues/304#issuecomment-2895375453.

`svelte-check` fails if you have a type `unknown`, so modified the recently added `customProperty` type to avoid `unknown`.


@hobbes7878  -- can you review and make sure you're happy with the new types for `customProperties`?