### PR TITLE
Fixes rootMargin logic in `Visible`

### DIFF
--- a/.changeset/gold-boats-dream.md
+++ b/.changeset/gold-boats-dream.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+Updates Visible to allow unit specification for top, bototm, right, left and adds a demo

--- a/src/components/Visible/Visible.mdx
+++ b/src/components/Visible/Visible.mdx
@@ -19,7 +19,8 @@ By default, `visible` will switch between `false` and `true` whenever the elemen
   import { Visible } from '@reuters-graphics/graphics-components';
 </script>
 
-<Visible>
+<!-- Optionally set your own `top`, `bottom`, `right` and `left` values with units -->
+<Visible top={{ value: 10, unit: 'px' }}>
   {#snippet children(visible)}
     {#if visible}
       <p>Visible!</p>

--- a/src/components/Visible/Visible.mdx
+++ b/src/components/Visible/Visible.mdx
@@ -19,8 +19,8 @@ By default, `visible` will switch between `false` and `true` whenever the elemen
   import { Visible } from '@reuters-graphics/graphics-components';
 </script>
 
-<!-- Optionally set your own `top`, `bottom`, `right` and `left` values with units -->
-<Visible top={{ value: 10, unit: 'px' }}>
+<!-- Optionally set your own `top`, `bottom`, `right` and `left` values with `px` or `%` units -->
+<Visible top="10px">
   {#snippet children(visible)}
     {#if visible}
       <p>Visible!</p>

--- a/src/components/Visible/Visible.stories.svelte
+++ b/src/components/Visible/Visible.stories.svelte
@@ -9,8 +9,9 @@
   });
 </script>
 
-<Story name="Demo" tags={['!autodocs', '!dev']}>
-  <Visible>
+<Story name="Demo">
+  <!-- Optionally set your own `top`, `bottom`, `right` and `left` values with units -->
+  <Visible top={{ value: 10, unit: 'px' }}>
     {#snippet children(visible)}
       {#if visible}
         <p>Visible!</p>

--- a/src/components/Visible/Visible.stories.svelte
+++ b/src/components/Visible/Visible.stories.svelte
@@ -2,6 +2,7 @@
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import Visible from './Visible.svelte';
+  import VisibleDemo from './demo/VisibleDemo.svelte';
 
   const { Story } = defineMeta({
     title: 'Components/Utilities/Visible',
@@ -10,14 +11,5 @@
 </script>
 
 <Story name="Demo">
-  <!-- Optionally set your own `top`, `bottom`, `right` and `left` values with units -->
-  <Visible top={{ value: 10, unit: 'px' }}>
-    {#snippet children(visible)}
-      {#if visible}
-        <p>Visible!</p>
-      {:else}
-        <p>Not yet visible.</p>
-      {/if}
-    {/snippet}
-  </Visible>
+  <VisibleDemo />
 </Story>

--- a/src/components/Visible/Visible.svelte
+++ b/src/components/Visible/Visible.svelte
@@ -9,13 +9,13 @@
      * Useful for loading expensive images or other media and then keeping them around once they're first loaded.
      */
     once?: boolean;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `top` with units. Units must be `px` or `%`. */
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `top` with units. Units must be  `px` or other [absolute lengths units](https://arc.net/l/quote/jkukcxqq), or `%`. */
     top?: string;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `bottom` with units. Units must be `px` or `%`. */
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `bottom` with units. Units must be  `px` or other [absolute lengths units](https://arc.net/l/quote/jkukcxqq), or `%`. */
     bottom?: string;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `left` with units. Units must be `px` or `%`. */
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `left` with units. Units must be  `px` or other [absolute lengths units](https://arc.net/l/quote/jkukcxqq), or `%`. */
     left?: string;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `right` with units. Units must be `px` or `%`. */
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `right` with units. Units must be  `px` or other [absolute lengths units](https://arc.net/l/quote/jkukcxqq), or `%`. */
     right?: string;
     /** Set the Intersection Observer [threshold](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold). */
     threshold?: number;

--- a/src/components/Visible/Visible.svelte
+++ b/src/components/Visible/Visible.svelte
@@ -59,7 +59,12 @@
   });
 </script>
 
-<div bind:this={container}>
+<div
+  bind:this={container}
+  class="visibility-tracker"
+  class:visible
+  class:not-visible={!visible}
+>
   {#if children}
     {@render children(visible)}
   {/if}

--- a/src/components/Visible/Visible.svelte
+++ b/src/components/Visible/Visible.svelte
@@ -9,13 +9,13 @@
      * Useful for loading expensive images or other media and then keeping them around once they're first loaded.
      */
     once?: boolean;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `top` with units. Accepted units are `px` or `%`. */
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `top` with units. Units must be `px` or `%`. */
     top?: string;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `bottom` with units. Accepted units are `px` or `%`. */
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `bottom` with units. Units must be `px` or `%`. */
     bottom?: string;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `left` with units. Accepted units are `px` or `%`. */
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `left` with units. Units must be `px` or `%`. */
     left?: string;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `right` with units. Accepted units are `px` or `%`. */
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `right` with units. Units must be `px` or `%`. */
     right?: string;
     /** Set the Intersection Observer [threshold](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold). */
     threshold?: number;

--- a/src/components/Visible/Visible.svelte
+++ b/src/components/Visible/Visible.svelte
@@ -57,8 +57,6 @@
       };
     }
   });
-
-  $effect(() => console.log('visible', visible));
 </script>
 
 <div bind:this={container}>

--- a/src/components/Visible/Visible.svelte
+++ b/src/components/Visible/Visible.svelte
@@ -11,24 +11,24 @@
     once?: boolean;
     /**
      * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `top`.
-     * Specify a value and unit (e.g. `px`, `%`, `vw`, `vh`, `rem`, `em`).
+     * Specify a pixel value.
      */
-    top?: { value: number; unit: 'px' | '%' | 'vw' | 'vh' | 'rem' | 'em' };
+    top?: number;
     /**
      * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `bottom`.
-     * Specify a value and unit (e.g. `px`, `%`, `vw`, `vh`, `rem`, `em`).
+     * Specify a pixel value.
      */
-    bottom?: { value: number; unit: 'px' | '%' | 'vw' | 'vh' | 'rem' | 'em' };
+    bottom?: number;
     /**
      * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `left`.
-     * Specify a value and unit (e.g. `px`, `%`, `vw`, `vh`, `rem`, `em`).
+     * Specify a pixel value.
      */
-    left?: { value: number; unit: 'px' | '%' | 'vw' | 'vh' | 'rem' | 'em' };
+    left?: number;
     /**
      * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `right`.
-     * Specify a value and unit (e.g. `px`, `%`, `vw`, `vh`, `rem`, `em`).
+     * Specify a pixel value.
      */
-    right?: { value: number; unit: 'px' | '%' | 'vw' | 'vh' | 'rem' | 'em' };
+    right?: number;
     /** Set the Intersection Observer [threshold](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold). */
     threshold?: number;
     children?: Snippet<[boolean]>;
@@ -36,10 +36,10 @@
 
   let {
     once = false,
-    top = { value: 0, unit: 'px' },
-    bottom = { value: 0, unit: 'px' },
-    left = { value: 0, unit: 'px' },
-    right = { value: 0, unit: 'px' },
+    top = 0,
+    bottom = 0,
+    left = 0,
+    right = 0,
     threshold = 0,
     children,
   }: Props = $props();
@@ -49,7 +49,7 @@
 
   onMount(() => {
     if (typeof IntersectionObserver !== 'undefined') {
-      const rootMargin = `${bottom.value}${bottom.unit} ${left.value}${left.unit} ${top.value}${top.unit} ${right.value}${right.unit}`;
+      const rootMargin = `${top}px ${right}px ${bottom}px ${left}px`;
 
       const observer = new IntersectionObserver(
         (entries) => {
@@ -71,11 +71,12 @@
     function handler() {
       if (container) {
         const bcr = container.getBoundingClientRect();
+
         visible =
-          bcr.bottom + bottom.value > 0 &&
-          bcr.right + right.value > 0 &&
-          bcr.top - top.value < window.innerHeight &&
-          bcr.left - left.value < window.innerWidth;
+          bcr.bottom + bottom > 0 &&
+          bcr.right + right > 0 &&
+          bcr.top - top < window.innerHeight &&
+          bcr.left - left < window.innerWidth;
       }
       if (visible && once) {
         window.removeEventListener('scroll', handler);
@@ -86,7 +87,7 @@
   });
 </script>
 
-<div bind:this={container}>
+<div class="visibility-tracker" bind:this={container}>
   {#if children}
     {@render children(visible)}
   {/if}

--- a/src/components/Visible/Visible.svelte
+++ b/src/components/Visible/Visible.svelte
@@ -1,6 +1,6 @@
 <!-- @component `Visible` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-utilities-visible--docs) -->
 <script lang="ts">
-  import { onMount, type Snippet } from 'svelte';
+  import { type Snippet } from 'svelte';
 
   interface Props {
     /**
@@ -29,8 +29,9 @@
      * Specify a pixel value.
      */
     right?: number;
-    /** Set the Intersection Observer [threshold](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold). */
-    threshold?: number;
+    /**
+     * A snippet that renders inside the component.
+     */
     children?: Snippet<[boolean]>;
   }
 
@@ -40,7 +41,6 @@
     bottom = 0,
     left = 0,
     right = 0,
-    threshold = 0,
     children,
   }: Props = $props();
 
@@ -62,31 +62,6 @@
       if (once && visible) visibleOnce = true;
     }
   }
-
-  onMount(() => {
-    if (typeof IntersectionObserver !== 'undefined') {
-      const rootMargin = `${top}px ${right}px ${bottom}px ${left}px`;
-
-      const observer = new IntersectionObserver(
-        (entries) => {
-          visible = entries[0].isIntersecting;
-          if (visible && once && container) {
-            observer.unobserve(container);
-          }
-        },
-        {
-          rootMargin,
-          threshold,
-        }
-      );
-
-      if (container) observer.observe(container);
-      // Unobserve when the component is unmounted
-      return () => {
-        if (container) observer.unobserve(container);
-      };
-    }
-  });
 </script>
 
 <svelte:window onscroll={scrollHandler} />

--- a/src/components/Visible/Visible.svelte
+++ b/src/components/Visible/Visible.svelte
@@ -9,26 +9,14 @@
      * Useful for loading expensive images or other media and then keeping them around once they're first loaded.
      */
     once?: boolean;
-    /**
-     * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `top`.
-     * Specify a pixel value.
-     */
-    top?: number;
-    /**
-     * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `bottom`.
-     * Specify a pixel value.
-     */
-    bottom?: number;
-    /**
-     * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `left`.
-     * Specify a pixel value.
-     */
-    left?: number;
-    /**
-     * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `right`.
-     * Specify a pixel value.
-     */
-    right?: number;
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `top` with units. Accepted units are `px` or `%`. */
+    top?: string;
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `bottom` with units. Accepted units are `px` or `%`. */
+    bottom?: string;
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `left` with units. Accepted units are `px` or `%`. */
+    left?: string;
+    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `right` with units. Accepted units are `px` or `%`. */
+    right?: string;
     /** Set the Intersection Observer [threshold](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold). */
     threshold?: number;
     children?: Snippet<[boolean]>;
@@ -36,48 +24,25 @@
 
   let {
     once = false,
-    top = 0,
-    bottom = 0,
-    left = 0,
-    right = 0,
+    top = '0px',
+    bottom = '0px',
+    left = '0px',
+    right = '0px',
     threshold = 0,
     children,
   }: Props = $props();
 
   let visible = $state(false);
-  let visibleOnce = $state(false);
   let container: HTMLElement | undefined = $state(undefined);
-
-  let observer: IntersectionObserver | undefined = $state(undefined);
-
-  // function scrollHandler() {
-  //   // Only trigger if `visibleOnce` is false
-  //   if (container && observer && !visibleOnce) {
-  //     const bcr = container.getBoundingClientRect();
-  //     visible =
-  //       bcr.bottom + bottom > 0 &&
-  //       bcr.right + right > 0 &&
-  //       bcr.top - top < window.innerHeight &&
-  //       bcr.left - left < window.innerWidth;
-
-  //     if (container) {
-  //       // console.log('Observing container:', observer);
-  //       observer.observe(container);
-  //     }
-
-  //     // If `once` is true, set `visibleOnce` to true once `visible` becomes true
-  //     if (once && visible) visibleOnce = true;
-  //   }
-  // }
 
   onMount(() => {
     if (typeof IntersectionObserver !== 'undefined') {
-      const rootMargin = `${top}px ${right}px ${bottom}px ${left}px`;
+      const rootMargin = `${bottom} ${left} ${top} ${right}`;
 
       const observer = new IntersectionObserver(
         (entries) => {
           visible = entries[0].isIntersecting;
-          if (visible && once && container && observer) {
+          if (visible && once && container) {
             observer.unobserve(container);
           }
         },
@@ -86,27 +51,17 @@
           threshold,
         }
       );
-
-      // Unobserve when the component is unmounted
+      if (container) observer.observe(container);
       return () => {
-        if (container && observer) observer.unobserve(container);
+        if (container) observer.observe(container);
       };
     }
   });
 
-  $effect(() => {
-    console.log('visible:', visible);
-  });
+  $effect(() => console.log('visible', visible));
 </script>
 
-<!-- <svelte:window onscroll={scrollHandler} /> -->
-
-<div
-  class="visibility-tracker"
-  class:visible
-  class:not-visible={!visible}
-  bind:this={container}
->
+<div bind:this={container}>
   {#if children}
     {@render children(visible)}
   {/if}

--- a/src/components/Visible/Visible.svelte
+++ b/src/components/Visible/Visible.svelte
@@ -9,14 +9,26 @@
      * Useful for loading expensive images or other media and then keeping them around once they're first loaded.
      */
     once?: boolean;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `top`. */
-    top?: number;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `bottom`. */
-    bottom?: number;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `left`. */
-    left?: number;
-    /** Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `right`. */
-    right?: number;
+    /**
+     * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `top`.
+     * Specify a value and unit (e.g. `px`, `%`, `vw`, `vh`, `rem`, `em`).
+     */
+    top?: { value: number; unit: 'px' | '%' | 'vw' | 'vh' | 'rem' | 'em' };
+    /**
+     * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `bottom`.
+     * Specify a value and unit (e.g. `px`, `%`, `vw`, `vh`, `rem`, `em`).
+     */
+    bottom?: { value: number; unit: 'px' | '%' | 'vw' | 'vh' | 'rem' | 'em' };
+    /**
+     * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `left`.
+     * Specify a value and unit (e.g. `px`, `%`, `vw`, `vh`, `rem`, `em`).
+     */
+    left?: { value: number; unit: 'px' | '%' | 'vw' | 'vh' | 'rem' | 'em' };
+    /**
+     * Set Intersection Observer [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#rootmargin) `right`.
+     * Specify a value and unit (e.g. `px`, `%`, `vw`, `vh`, `rem`, `em`).
+     */
+    right?: { value: number; unit: 'px' | '%' | 'vw' | 'vh' | 'rem' | 'em' };
     /** Set the Intersection Observer [threshold](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold). */
     threshold?: number;
     children?: Snippet<[boolean]>;
@@ -24,10 +36,10 @@
 
   let {
     once = false,
-    top = 0,
-    bottom = 0,
-    left = 0,
-    right = 0,
+    top = { value: 0, unit: 'px' },
+    bottom = { value: 0, unit: 'px' },
+    left = { value: 0, unit: 'px' },
+    right = { value: 0, unit: 'px' },
     threshold = 0,
     children,
   }: Props = $props();
@@ -37,7 +49,7 @@
 
   onMount(() => {
     if (typeof IntersectionObserver !== 'undefined') {
-      const rootMargin = `${bottom}px ${left}px ${top}px ${right}px`;
+      const rootMargin = `${bottom.value}${bottom.unit} ${left.value}${left.unit} ${top.value}${top.unit} ${right.value}${right.unit}`;
 
       const observer = new IntersectionObserver(
         (entries) => {
@@ -53,17 +65,17 @@
       );
       if (container) observer.observe(container);
       return () => {
-        if (container) observer.observe(container);
+        if (container) observer.unobserve(container);
       };
     }
     function handler() {
       if (container) {
         const bcr = container.getBoundingClientRect();
         visible =
-          bcr.bottom + bottom > 0 &&
-          bcr.right + right > 0 &&
-          bcr.top - top < window.innerHeight &&
-          bcr.left - left < window.innerWidth;
+          bcr.bottom + bottom.value > 0 &&
+          bcr.right + right.value > 0 &&
+          bcr.top - top.value < window.innerHeight &&
+          bcr.left - left.value < window.innerWidth;
       }
       if (visible && once) {
         window.removeEventListener('scroll', handler);

--- a/src/components/Visible/Visible.svelte
+++ b/src/components/Visible/Visible.svelte
@@ -53,7 +53,7 @@
       );
       if (container) observer.observe(container);
       return () => {
-        if (container) observer.observe(container);
+        if (container) observer.unobserve(container);
       };
     }
   });

--- a/src/components/Visible/demo/VisibleDemo.svelte
+++ b/src/components/Visible/demo/VisibleDemo.svelte
@@ -5,7 +5,7 @@
   import FeaturePhoto from '../../FeaturePhoto/FeaturePhoto.svelte';
   import sharkSrc from '../../FeaturePhoto/images/shark.jpg';
 
-  let top = 200;
+  let top = 100;
 
   const demoText =
     'Take a look at the *Elements* tab in Inspector to see how the photo in the middle of the page appears in the DOM only when its container comes into view.';

--- a/src/components/Visible/demo/VisibleDemo.svelte
+++ b/src/components/Visible/demo/VisibleDemo.svelte
@@ -5,24 +5,28 @@
   import FeaturePhoto from '../../FeaturePhoto/FeaturePhoto.svelte';
   import sharkSrc from '../../FeaturePhoto/images/shark.jpg';
 
+  let top = 200;
+
   const demoText =
-    "Adjust the window dimension to see what happens when `<div class='visibility-tracker'>` comes into <a href='https://codepen.io/michellebarker/full/xxwLpRG'>Internsection Observer's</a> view.";
+    'Take a look at the *Elements* tab in Inspector to see how the photo in the middle of the page appears in the DOM only when its container comes into view.';
+
+  let demoText2 = $derived(
+    `The top value for \`rootMargin\` is set to \`${top}px\` in this demo. Read about how \`rootMargin\` affects the <a href='https://codepen.io/michellebarker/full/xxwLpRG'>Intersection Observer's behaviour here</a>.`
+  );
 
   const text =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
-
-  let top = 500;
 </script>
 
 <BodyText text={`**${demoText}**`} />
+
+<BodyText text={`**${demoText2}**`} />
+<BodyText {text} />
 <BodyText {text} />
 <BodyText {text} />
 <BodyText {text} />
 
-<!-- <div class="root-margin-demo" style="padding-top:{top}px;">
-  <p class="margin-value font-note font-medium">Root margin top: {top}px</p>
-</div> -->
-<Visible {top}>
+<Visible {top} once={false}>
   {#snippet children(visible)}
     {#if visible}
       <FeaturePhoto
@@ -31,29 +35,12 @@
         caption="Carcharodon carcharias - REUTERS"
       />
     {:else}
-      <Block>
-        <h2 class="not-visible">Not yet visible.</h2>
-      </Block>
+      <Block><h2>Not yet visible.</h2></Block>
     {/if}
   {/snippet}
 </Visible>
 <BodyText {text} />
 <BodyText {text} />
-
-<style lang="scss">
-  @use '../../../scss/mixins' as mixins;
-
-  .root-margin-demo {
-    position: relative;
-    background: lightblue;
-    margin: auto;
-    max-width: mixins.$column-width-normal;
-
-    p.margin-value {
-      position: absolute;
-      top: 5px;
-      left: 50%;
-      transform: translateX(-50%);
-    }
-  }
-</style>
+<BodyText {text} />
+<BodyText {text} />
+<BodyText {text} />

--- a/src/components/Visible/demo/VisibleDemo.svelte
+++ b/src/components/Visible/demo/VisibleDemo.svelte
@@ -5,7 +5,7 @@
   import FeaturePhoto from '../../FeaturePhoto/FeaturePhoto.svelte';
   import sharkSrc from '../../FeaturePhoto/images/shark.jpg';
 
-  let top = 100;
+  let top = '150px';
 
   const demoText =
     'Take a look at the *Elements* tab in Inspector to see how the photo in the middle of the page appears in the DOM only when its container comes into view.';

--- a/src/components/Visible/demo/VisibleDemo.svelte
+++ b/src/components/Visible/demo/VisibleDemo.svelte
@@ -6,7 +6,7 @@
   import sharkSrc from '../../FeaturePhoto/images/shark.jpg';
 
   const demoText =
-    "Adjust the window dimension to see what happens when `<div class=\'visibility-tracker\'>` comes into <a href=\'https://codepen.io/michellebarker/full/xxwLpRG\'>Internsection Observer's</a> view.";
+    "Adjust the window dimension to see what happens when `<div class='visibility-tracker'>` comes into <a href='https://codepen.io/michellebarker/full/xxwLpRG'>Internsection Observer's</a> view.";
 
   const text =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';

--- a/src/components/Visible/demo/VisibleDemo.svelte
+++ b/src/components/Visible/demo/VisibleDemo.svelte
@@ -2,11 +2,16 @@
   import Visible from '../Visible.svelte';
   import BodyText from '../../BodyText/BodyText.svelte';
   import Block from '../../Block/Block.svelte';
+  import FeaturePhoto from '../../FeaturePhoto/FeaturePhoto.svelte';
+  import sharkSrc from '../../FeaturePhoto/images/shark.jpg';
 
   const demoText =
-    'Adjust the window dimension to see what happens when the HTML element wrapped in `Visible` becomes enters the viewport.';
+    "Adjust the window dimension to see what happens when `<div class=\'visibility-tracker\'>` comes into <a href=\'https://codepen.io/michellebarker/full/xxwLpRG\'>Internsection Observer's</a> view.";
+
   const text =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+  let top = 500;
 </script>
 
 <BodyText text={`**${demoText}**`} />
@@ -14,22 +19,41 @@
 <BodyText {text} />
 <BodyText {text} />
 
-<Block>
-  <Visible top={{ value: 10, unit: 'px' }}>
-    {#snippet children(visible)}
-      {#if visible}
-        <h2>Visible!</h2>
-      {:else}
-        <h2>Not yet visible.</h2>
-      {/if}
-    {/snippet}
-  </Visible>
-</Block>
-
-<BodyText {text} />
-<BodyText {text} />
+<!-- <div class="root-margin-demo" style="padding-top:{top}px;">
+  <p class="margin-value font-note font-medium">Root margin top: {top}px</p>
+</div> -->
+<Visible {top}>
+  {#snippet children(visible)}
+    {#if visible}
+      <FeaturePhoto
+        src={sharkSrc}
+        altText="A shark!"
+        caption="Carcharodon carcharias - REUTERS"
+      />
+    {:else}
+      <Block>
+        <h2 class="not-visible">Not yet visible.</h2>
+      </Block>
+    {/if}
+  {/snippet}
+</Visible>
 <BodyText {text} />
 <BodyText {text} />
 
 <style lang="scss">
+  @use '../../../scss/mixins' as mixins;
+
+  .root-margin-demo {
+    position: relative;
+    background: lightblue;
+    margin: auto;
+    max-width: mixins.$column-width-normal;
+
+    p.margin-value {
+      position: absolute;
+      top: 5px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  }
 </style>

--- a/src/components/Visible/demo/VisibleDemo.svelte
+++ b/src/components/Visible/demo/VisibleDemo.svelte
@@ -3,11 +3,13 @@
   import BodyText from '../../BodyText/BodyText.svelte';
   import Block from '../../Block/Block.svelte';
 
+  const demoText =
+    'Adjust the window dimension to see what happens when the HTML element wrapped in `Visible` becomes enters the viewport.';
   const text =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
 </script>
 
-<BodyText {text} />
+<BodyText text={`**${demoText}**`} />
 <BodyText {text} />
 <BodyText {text} />
 <BodyText {text} />

--- a/src/components/Visible/demo/VisibleDemo.svelte
+++ b/src/components/Visible/demo/VisibleDemo.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import Visible from '../Visible.svelte';
+  import BodyText from '../../BodyText/BodyText.svelte';
+  import Block from '../../Block/Block.svelte';
+
+  const text =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+</script>
+
+<BodyText {text} />
+<BodyText {text} />
+<BodyText {text} />
+<BodyText {text} />
+
+<Block>
+  <Visible top={{ value: 10, unit: 'px' }}>
+    {#snippet children(visible)}
+      {#if visible}
+        <h2>Visible!</h2>
+      {:else}
+        <h2>Not yet visible.</h2>
+      {/if}
+    {/snippet}
+  </Visible>
+</Block>
+
+<BodyText {text} />
+<BodyText {text} />
+<BodyText {text} />
+<BodyText {text} />
+
+<style lang="scss">
+</style>


### PR DESCRIPTION
### Background
I revisited this component after https://github.com/reuters-graphics/graphics-components/issues/221 was filed. The short answer on https://github.com/reuters-graphics/graphics-components/issues/221 is that we should stick to only allowing `px`. This is because `getBoundingClientRect` only works with px, and rootMargin only works with px or % and no relative units like vh.

When revisiting this component, I discovered that the rootMargin props weren't working. For example, even when I set `top` to `200px`, the `visible` variable switched values when the top of the container came into view, not 200px above the top of the container. 

Previously, the component used two methods to check whether the container is visible: IntersectionObserver and calculations based on the top, bottom, right and left values from `container.getBoundingClientRect()`. 

The main issues were:
- IntersectionObserver was firing in `onMount` only
- IntersectionObserver wasn't honouring the top, bottom, right, left values 
- The function `handler` wasn't firing at all, probably partly because of Svelte 5 changes in how it handles events 

I tested both methods and came to the conclusion that we only need `container.getBoundingClientRect()` to control the value for `visible`, so in this PR, I got rid of IntersectionObserver in onMount and rewrote `handler` so that it would fire properly.

### What's in this pull request
- Gets rid of IntersectionObserver in onMount
- Uses Svelte's `<svelte:window onscroll>` to trigger scroll events and removes `window.addEventListener('scroll', handler)
- Renames and tweaks `handler` to `scrollHandler`
- Adds a `not-visible` and `visible` class to the container div 
- Updates docs
- Adds a demo page.