### PR TITLE
Scroller typo fixes

### DIFF
--- a/.changeset/soft-jars-sin.md
+++ b/.changeset/soft-jars-sin.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+Fix typos in Scroller

--- a/src/components/Scroller/Background.svelte
+++ b/src/components/Scroller/Background.svelte
@@ -25,7 +25,7 @@
 {#each steps as step, i}
   {#if showStep(i)}
     <div
-      class={`step step-${i + 1} w-full absolute`}
+      class={`step-background step-${i + 1} w-full absolute`}
       class:visible={isVisible(i)}
       class:invisible={!isVisible(i)}
     >

--- a/src/components/Scroller/Scroller.mdx
+++ b/src/components/Scroller/Scroller.mdx
@@ -122,7 +122,7 @@ Then parse the relevant ArchieML block object before passing to the `Scroller` c
   {#if block.type === 'ai-scroller'}
     <Scroller
       id={block.id}
-      backgroundWidth={block.width}
+      backgroundWidth={block.backgroundWidth}
       foregroundPosition={block.foregroundPosition}
       stackBackground={truthy(block.stackBackground)}
       steps={block.steps.map((step) => ({


### PR DESCRIPTION
### What's in this pull request

- Fixed Scroller documentation so that `backgroundWidth={block.backgroundWidth}`, not backgroundWidth={block.width}
- Background.svelte had a typo; the div should have the class `step-background` not `step`.  Fixed the div class to `step-background`