### PR TITLE
adds translation byline example

### DIFF
--- a/.changeset/young-rules-lick.md
+++ b/.changeset/young-rules-lick.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+Adds byline translation examples

--- a/src/components/Byline/Byline.mdx
+++ b/src/components/Byline/Byline.mdx
@@ -101,7 +101,7 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customis
 </script>
 ```
 
-```javascript
+```svelte
 <!-- In App.svelte -->
 <!-- Define custom translation snippets for different languages above the <Byline/> component -->
 {#snippet esByline()}
@@ -127,7 +127,7 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customis
     })}&nbsp;&nbsp;{formatTime(content.publishTime)}</time
   >
 {/snippet}
-```
+``` 
 
 ```svelte
 <!-- In App.svelte -->

--- a/src/components/Byline/Byline.mdx
+++ b/src/components/Byline/Byline.mdx
@@ -127,7 +127,7 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customis
     })}&nbsp;&nbsp;{formatTime(content.publishTime)}</time
   >
 {/snippet}
-``` 
+```
 
 ```svelte
 <!-- In App.svelte -->

--- a/src/components/Byline/Byline.mdx
+++ b/src/components/Byline/Byline.mdx
@@ -83,6 +83,60 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to customise the byline, 
 
 <Canvas of={BylineStories.Customised} />
 
+
+## Translated byline and datelines
+
+Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customise the byline, published and updated datelines for different languages.
+
+```svelte
+<!-- In App.svelte -->
+<script>
+  import { Byline, getAuthorPageUrl, formatTime } from '@reuters-graphics/graphics-components';
+  import content from '$locales/en/content.json';
+
+ // Note: In graphics kit, `locale` is already defined in `App.svelte`
+</script>
+
+<!-- Define custom translation snippets for different languages before using the <Byline/> component -->
+{#snippet esByline()}
+  Por
+  {#each content.authors as author, i}
+    <a
+      class="no-underline whitespace-nowrap text-primary font-bold"
+      href={getAuthorPageUrl(author)}
+      rel="author"
+    >
+      {author.trim()}</a
+    >{#if content.authors.length > 1 && i < content.authors.length - 2},{/if}
+    {#if content.authors.length > 1 && i === content.authors.length - 2}y&nbsp;{/if}
+  {/each}
+{/snippet}
+
+{#snippet esPublished()}
+  Publicado <time datetime="2026-04-08T10:00:00.000Z">
+    {new Date(content.publishTime).toLocaleDateString('es-ES', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })}&nbsp;&nbsp;{formatTime(content.publishTime)}</time
+  >
+{/snippet}
+
+
+<!-- Conditionally render custom translation snippets depending on the locale -->
+<Byline
+  authors={content.authors}
+  publishTime={content.publishTime}
+  byline={locale === 'es' ? esByline : undefined}
+  published={locale === 'es' ? esPublished : undefined}
+/>
+
+```
+
+
+
+<Canvas of={BylineStories.Translation} />
+
 ## Custom author page
 
 By default, the `Byline` component will hyperlink each author's byline to their Reuters.com page, formatted `https://www.reuters.com/authors/{author-slug}/`.

--- a/src/components/Byline/Byline.mdx
+++ b/src/components/Byline/Byline.mdx
@@ -99,8 +99,11 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customis
 
   // Note: In graphics kit, `locale` is already defined in `App.svelte`
 </script>
+```
 
-<!-- Define custom translation snippets for different languages before using the <Byline/> component -->
+```javascript
+<!-- In App.svelte -->
+<!-- Define custom translation snippets for different languages above the <Byline/> component -->
 {#snippet esByline()}
   Por
   {#each content.authors as author, i}
@@ -124,7 +127,10 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customis
     })}&nbsp;&nbsp;{formatTime(content.publishTime)}</time
   >
 {/snippet}
+```
 
+```svelte
+<!-- In App.svelte -->
 <!-- Conditionally render custom translation snippets depending on the locale -->
 <Byline
   authors={content.authors}

--- a/src/components/Byline/Byline.mdx
+++ b/src/components/Byline/Byline.mdx
@@ -83,7 +83,6 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to customise the byline, 
 
 <Canvas of={BylineStories.Customised} />
 
-
 ## Translated byline and datelines
 
 Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customise the byline, published and updated datelines for different languages.
@@ -91,10 +90,14 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customis
 ```svelte
 <!-- In App.svelte -->
 <script>
-  import { Byline, getAuthorPageUrl, formatTime } from '@reuters-graphics/graphics-components';
+  import {
+    Byline,
+    getAuthorPageUrl,
+    formatTime,
+  } from '@reuters-graphics/graphics-components';
   import content from '$locales/en/content.json';
 
- // Note: In graphics kit, `locale` is already defined in `App.svelte`
+  // Note: In graphics kit, `locale` is already defined in `App.svelte`
 </script>
 
 <!-- Define custom translation snippets for different languages before using the <Byline/> component -->
@@ -122,7 +125,6 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customis
   >
 {/snippet}
 
-
 <!-- Conditionally render custom translation snippets depending on the locale -->
 <Byline
   authors={content.authors}
@@ -130,10 +132,7 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customis
   byline={locale === 'es' ? esByline : undefined}
   published={locale === 'es' ? esPublished : undefined}
 />
-
 ```
-
-
 
 <Canvas of={BylineStories.Translation} />
 

--- a/src/components/Byline/Byline.mdx
+++ b/src/components/Byline/Byline.mdx
@@ -46,7 +46,7 @@ updateTime: 2021-09-12T12:57:00.000Z
 ```svelte
 <script>
   import { Byline } from '@reuters-graphics/graphics-components';
-  import content from '$locales/en/content.json';
+  let { content }: Props = $props();
 </script>
 
 <Byline
@@ -95,7 +95,8 @@ Use [snippets](https://svelte.dev/docs/svelte/snippet) to conditionally customis
     getAuthorPageUrl,
     formatTime,
   } from '@reuters-graphics/graphics-components';
-  import content from '$locales/en/content.json';
+
+  let { content }: Props = $props();
 
   // Note: In graphics kit, `locale` is already defined in `App.svelte`
 </script>

--- a/src/components/Byline/Byline.stories.svelte
+++ b/src/components/Byline/Byline.stories.svelte
@@ -1,7 +1,6 @@
 <script module lang="ts">
-  import slug from 'slugify';
-
   import { defineMeta } from '@storybook/addon-svelte-csf';
+  import { formatTime, getAuthorPageUrl } from '../../utils/index.js';
   import Byline from './Byline.svelte';
 
   const { Story } = defineMeta({
@@ -22,19 +21,8 @@
     'Anurag Rao',
     'Mariano Zafra',
   ];
-  const formatTime = (datetime: string) =>
-    new Date(datetime).toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-      timeZoneName: 'short',
-    });
 
   let publishTime = '2021-09-12T00:00:00Z';
-
-  const getAuthorPageUrl = (author: string): string => {
-    const authorSlug = slug(author.trim(), { lower: true });
-    return `https://www.reuters.com/authors/${authorSlug}/`;
-  };
 
   let locale = 'es';
 </script>
@@ -87,7 +75,7 @@
   >
 {/snippet}
 
-<Story name="Translation">
+<Story name="Translation" tags={['!autodocs', '!dev']}>
   In locale = `es`:
   <Byline
     publishTime="2021-09-12T00:00:00Z"

--- a/src/components/Byline/Byline.stories.svelte
+++ b/src/components/Byline/Byline.stories.svelte
@@ -1,4 +1,6 @@
 <script module lang="ts">
+  import slug from 'slugify';
+
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import Byline from './Byline.svelte';
 
@@ -13,17 +15,34 @@
       },
     },
   });
+
+  let authors = [
+    'Dea Bankova',
+    'Prasanta Kumar Dutta',
+    'Anurag Rao',
+    'Mariano Zafra',
+  ];
+  const formatTime = (datetime: string) =>
+    new Date(datetime).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    });
+
+  let publishTime = '2021-09-12T00:00:00Z';
+
+  const getAuthorPageUrl = (author: string): string => {
+    const authorSlug = slug(author.trim(), { lower: true });
+    return `https://www.reuters.com/authors/${authorSlug}/`;
+  };
+
+  let locale = 'es';
 </script>
 
 <Story
   name="Demo"
   args={{
-    authors: [
-      'Dea Bankova',
-      'Prasanta Kumar Dutta',
-      'Anurag Rao',
-      'Mariano Zafra',
-    ],
+    authors,
     publishTime: new Date('2021-09-12').toISOString(),
     updateTime: new Date('2021-09-12T13:57:00').toISOString(),
   }}
@@ -43,17 +62,55 @@
   </Byline>
 </Story>
 
+<!-- Translation snippets -->
+{#snippet esByline()}
+  Por
+  {#each authors as author, i}
+    <a
+      class="no-underline whitespace-nowrap text-primary font-bold"
+      href={getAuthorPageUrl(author)}
+      rel="author"
+    >
+      {author.trim()}</a
+    >{#if authors.length > 1 && i < authors.length - 2},{/if}
+    {#if authors.length > 1 && i === authors.length - 2}y&nbsp;{/if}
+  {/each}
+{/snippet}
+
+{#snippet esPublished()}
+  Publicado <time datetime="2026-04-08T10:00:00.000Z">
+    {new Date(publishTime).toLocaleDateString('es-ES', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })}&nbsp;&nbsp;{formatTime(publishTime)}</time
+  >
+{/snippet}
+
+<Story name="Translation">
+  In locale = `es`:
+  <Byline
+    publishTime="2021-09-12T00:00:00Z"
+    {authors}
+    byline={locale === 'es' ? esByline : undefined}
+    published={locale === 'es' ? esPublished : undefined}
+  ></Byline>
+
+  In locale = `en`:
+  <Byline
+    publishTime="2021-09-12T00:00:00Z"
+    {authors}
+    byline={undefined}
+    published={undefined}
+  />
+</Story>
+
 <Story
   name="Custom author page"
   exportName="CustomAuthorPage"
   tags={['!autodocs', '!dev']}
   args={{
-    authors: [
-      'Dea Bankova',
-      'Prasanta Kumar Dutta',
-      'Anurag Rao',
-      'Mariano Zafra',
-    ],
+    authors,
     publishTime: '2021-09-12T00:00:00Z',
     updateTime: '2021-09-12T13:57:00Z',
     getAuthorPage: (author: string) => {

--- a/src/components/Byline/Byline.svelte
+++ b/src/components/Byline/Byline.svelte
@@ -1,6 +1,6 @@
 <!-- @component `Byline` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-text-elements-byline--docs) -->
 <script lang="ts">
-  import { getAuthorPageUrl } from '../../utils';
+  import { getAuthorPageUrl, formatTime } from '../../utils';
   import Block from '../Block/Block.svelte';
   import { apdate } from 'journalize';
   import type { Snippet } from 'svelte';
@@ -73,13 +73,6 @@
     if (!Date.parse(datetime)) return false;
     return true;
   };
-
-  const formatTime = (datetime: string) =>
-    new Date(datetime).toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-      timeZoneName: 'short',
-    });
 
   const areSameDay = (first: Date, second: Date) =>
     first.getFullYear() === second.getFullYear() &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { default as cssVariables } from './actions/cssVariables/index';
 export { default as resizeObserver } from './actions/resizeObserver/index';
 
 // Utils
-export { prettifyDate } from './utils/index';
+export { prettifyDate, getAuthorPageUrl, formatTime } from './utils/index';
 
 // Components
 export {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -103,7 +103,6 @@ const prettifyAmPm = (text: string) => {
 export const slugify = (str: string) =>
   slug(str, { lower: true, strict: true });
 
-
 /** Formats a datetime string into a localized time string with hour, minute, and time zone for the dateline */
 export const formatTime = (datetime: string) =>
   new Date(datetime).toLocaleTimeString([], {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -102,3 +102,12 @@ const prettifyAmPm = (text: string) => {
  */
 export const slugify = (str: string) =>
   slug(str, { lower: true, strict: true });
+
+
+/** Formats a datetime string into a localized time string with hour, minute, and time zone for the dateline */
+export const formatTime = (datetime: string) =>
+  new Date(datetime).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });


### PR DESCRIPTION
Adds an example of using custom byline and dateline snippets conditionally, based on locale.

Closes  #406
