### PR TITLE
redesign btn

### DIFF
--- a/.changeset/common-lions-smell.md
+++ b/.changeset/common-lions-smell.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+Redigns language button

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,10 @@
 {
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "svelte",
-    "jsx"
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "svelte", "jsx"],
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "emmet.excludeLanguages": [
-    "markdown",
-    "scss"
-  ],
+  "emmet.excludeLanguages": ["markdown", "scss"],
   "files.associations": {
     "*.svx": "mdx"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,18 @@
 {
-  "eslint.validate": ["javascript", "javascriptreact", "svelte", "jsx"],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "svelte",
+    "jsx"
+  ],
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "emmet.excludeLanguages": ["markdown", "scss"],
+  "emmet.excludeLanguages": [
+    "markdown",
+    "scss"
+  ],
   "files.associations": {
     "*.svx": "mdx"
   },
@@ -14,5 +22,6 @@
   "[svelte]": {
     "editor.defaultFormatter": "svelte.svelte-vscode"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "snyk.advanced.autoSelectOrganization": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,5 @@
   "[svelte]": {
     "editor.defaultFormatter": "svelte.svelte-vscode"
   },
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "snyk.advanced.autoSelectOrganization": true
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/components/LanguageButton/LanguageButton.mdx
+++ b/src/components/LanguageButton/LanguageButton.mdx
@@ -25,7 +25,6 @@ The `LanguageButton` component creates a button that switches between an article
 
 If a translated embed page does not exist, add `LanguageButton` conditionally so it only renders when `embedded` is `false`. This prevents a toggle button from appearing on the English embed page.
 
-
 ```svelte
 {#if !embedded}
   <LanguageButton {locale} {base} />
@@ -38,6 +37,7 @@ For graphics kit: If a translated embed page exists at `pages/embeds/{locale}/pa
 <!-- Pass `embedded` to `LanguageButton` if the embed page is translated -->
 <LanguageButton {locale} {embedded} {base} />
 ```
+
 <Canvas of={LanguageButtonStories.Demo} />
 
 ## Customise language and button label

--- a/src/components/LanguageButton/LanguageButton.mdx
+++ b/src/components/LanguageButton/LanguageButton.mdx
@@ -21,11 +21,23 @@ The `LanguageButton` component creates a button that switches between an article
   // Additionally, pass `locale = 'en'` as a prop
   let { embedded = false, locale = 'en' }: Props = $props();
 </script>
+```
 
+If a translated embed page does not exist, add `LanguageButton` conditionally so it only renders when `embedded` is `false`. This prevents a toggle button from appearing on the English embed page.
+
+
+```svelte
+{#if !embedded}
+  <LanguageButton {locale} {base} />
+{/if}
+```
+
+For graphics kit: If a translated embed page exists at `pages/embeds/{locale}/page/+page.svelte`, pass the `embedded` prop to `LanguageButton` so it links to the correct URLs for the main article and the embed page.
+
+```svelte
 <!-- Pass `embedded` to `LanguageButton` if the embed page is translated -->
 <LanguageButton {locale} {embedded} {base} />
 ```
-
 <Canvas of={LanguageButtonStories.Demo} />
 
 ## Customise language and button label

--- a/src/components/LanguageButton/LanguageButton.svelte
+++ b/src/components/LanguageButton/LanguageButton.svelte
@@ -84,7 +84,7 @@
       border: none;
       transition: color 0.25s ease;
       text-decoration: underline;
-      text-decoration-color: #d5d5d5;
+      text-decoration-color: #afafaf;
     }
 
     #translate-button:hover {

--- a/src/components/LanguageButton/LanguageButton.svelte
+++ b/src/components/LanguageButton/LanguageButton.svelte
@@ -76,22 +76,19 @@
       text-transform: uppercase;
       letter-spacing: 0.06rem;
       font-size: var(--theme-font-size-xs);
-      background-color: #d3e1e1;
       color: rgb(91 101 101);
-      padding: 2px 12px;
-      border-radius: 4px;
       z-index: 10;
       cursor: pointer;
       position: relative;
+      background: none;
       border: none;
-      transition:
-        background-color 0.25s ease,
-        color 0.25s ease;
+      transition: color 0.25s ease;
     }
 
     #translate-button:hover {
-      background-color: #889d9b;
-      color: #ebf7f7;
+      color: #333333;
+      text-decoration: underline;
+      border-bottom: none;
     }
   }
 </style>

--- a/src/components/LanguageButton/LanguageButton.svelte
+++ b/src/components/LanguageButton/LanguageButton.svelte
@@ -83,12 +83,13 @@
       background: none;
       border: none;
       transition: color 0.25s ease;
+      text-decoration: underline;
+      text-decoration-color: #d5d5d5;
     }
 
     #translate-button:hover {
       color: #333333;
       text-decoration: underline;
-      border-bottom: none;
     }
   }
 </style>


### PR DESCRIPTION
### What's in this pull request

Redesigned the translation button to look more like a link (which it is, in practice) and generally make it more subtle/bring it down in the hierarchy. Curious if @allyjlevine has thoughts, I just thought the one on cuba was a bit intense to be the default for all stories.   


### Before 
<img width="182" height="42" alt="image" src="https://github.com/user-attachments/assets/d8c6e272-d719-45a3-ab0e-3fa4374d3748" />

### After 
<img width="161" height="39" alt="image" src="https://github.com/user-attachments/assets/dbb0cd28-b4e8-4b34-8f34-6bfd499bcc4f" />