### PR TITLE
Add Geocoder component for Mapbox location search

### DIFF
--- a/.changeset/add-geocoder-component.md
+++ b/.changeset/add-geocoder-component.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Add Geocoder component for autocomplete location search using Mapbox Geocoding v6 API

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -28,4 +28,6 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: 'build:docs'
+        env:
+          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.VITE_MAPBOX_ACCESS_TOKEN }}
           # exitZeroOnChanges: false

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,9 +3,54 @@ name: Manually publish docs
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
 jobs:
-  docs:
-    uses: reuters-graphics/action-workflows/.github/workflows/docs.yaml@main
-    secrets: inherit
-    with:
-      node_version: '20'
+  publish:
+    name: Publish docs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Build all packages
+        run: pnpm run --recursive --if-present build
+
+      - name: Build docs
+        run: pnpm run --if-present build:docs
+        env:
+          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.VITE_MAPBOX_ACCESS_TOKEN }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,54 +3,9 @@ name: Manually publish docs
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
-
-concurrency:
-  group: 'pages'
-  cancel-in-progress: true
-
 jobs:
-  publish:
-    name: Publish docs
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm i
-
-      - name: Build all packages
-        run: pnpm run --recursive --if-present build
-
-      - name: Build docs
-        run: pnpm run --if-present build:docs
-        env:
-          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.VITE_MAPBOX_ACCESS_TOKEN }}
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './docs'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  docs:
+    uses: reuters-graphics/action-workflows/.github/workflows/docs.yaml@main
+    secrets: inherit
+    with:
+      node_version: '20'

--- a/src/components/Geocoder/Geocoder.mdx
+++ b/src/components/Geocoder/Geocoder.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/blocks';
+
+import * as GeocoderStories from './Geocoder.stories.svelte';
+
+<Meta of={GeocoderStories} />
+
+# Geocoder
+
+The `Geocoder` component provides an autocomplete location search powered by the [Mapbox Geocoding v6 API](https://docs.mapbox.com/api/search/geocoding-v6/). It returns coordinates and a place name via the `onselect` callback.
+
+```svelte
+<script>
+  import { Geocoder } from '@reuters-graphics/graphics-components';
+
+  const MAPBOX_TOKEN = 'your_mapbox_token';
+
+  function handleSelect(location) {
+    console.log(location.name, location.lng, location.lat);
+  }
+</script>
+
+<Geocoder accessToken={MAPBOX_TOKEN} onselect={handleSelect} />
+```
+
+The `accessToken` prop is required. Look up the Reuters Mapbox token in the team's 1Password vault. All [Mapbox forward geocoding options](https://docs.mapbox.com/api/search/geocoding-v6/#forward-geocoding) are available as props, including `country`, `language`, `types`, `bbox`, `proximity`, `limit`, and `worldview`.
+
+<Canvas of={GeocoderStories.Demo} />

--- a/src/components/Geocoder/Geocoder.stories.svelte
+++ b/src/components/Geocoder/Geocoder.stories.svelte
@@ -1,0 +1,23 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import Geocoder from './Geocoder.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Components/Controls/Geocoder',
+    component: Geocoder,
+  });
+</script>
+
+<script lang="ts">
+  const accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? '';
+
+  function handleSelect(location: { lng: number; lat: number; name: string }) {
+    console.log('Selected:', location);
+  }
+</script>
+
+<Story name="Demo">
+  <div style="min-height: 330px; padding-top: 1rem;">
+    <Geocoder {accessToken} onselect={handleSelect} />
+  </div>
+</Story>

--- a/src/components/Geocoder/Geocoder.svelte
+++ b/src/components/Geocoder/Geocoder.svelte
@@ -1,0 +1,303 @@
+<!-- @component `Geocoder` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-controls-geocoder--docs) -->
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { geocode, type GeocodeFeature, type GeocodeOptions } from './geocode';
+  import MagnifyingGlass from '../SearchInput/components/MagnifyingGlass.svelte';
+  import X from '../SearchInput/components/X.svelte';
+
+  interface Props extends Omit<GeocodeOptions, 'accessToken'> {
+    /** Mapbox public access token. */
+    accessToken: string;
+    /** Placeholder text shown in the search input. */
+    searchPlaceholder?: string;
+    /** Callback fired when a location is selected from the results. */
+    onselect?: (location: { lng: number; lat: number; name: string }) => void;
+  }
+
+  let {
+    accessToken,
+    searchPlaceholder = 'Search for a location',
+    onselect,
+    autocomplete = true,
+    bbox,
+    country,
+    language = ['en'],
+    limit = 5,
+    proximity,
+    types,
+    worldview,
+    permanent,
+    entrances,
+  }: Props = $props();
+
+  let query = $state('');
+  let suggestions: GeocodeFeature[] = $state([]);
+  let selectedIndex = $state(-1);
+  let focused = $state(false);
+
+  let showDropdown = $derived(suggestions.length > 0 && focused);
+
+  const instanceId = Math.random().toString(36).slice(2, 9);
+  const listboxId = `geocoder-listbox-${instanceId}`;
+
+  let inputEl: HTMLInputElement;
+  let debounceTimer: ReturnType<typeof setTimeout>;
+  let abortController: AbortController | null = null;
+
+  function handleInput() {
+    selectedIndex = -1;
+    clearTimeout(debounceTimer);
+    abortController?.abort();
+
+    if (query.length < 2) {
+      suggestions = [];
+      return;
+    }
+
+    debounceTimer = setTimeout(async () => {
+      abortController = new AbortController();
+      try {
+        suggestions = await geocode(
+          query,
+          {
+            accessToken,
+            autocomplete,
+            bbox,
+            country,
+            language,
+            limit,
+            proximity,
+            types,
+            worldview,
+            permanent,
+            entrances,
+          },
+          abortController.signal
+        );
+      } catch (e) {
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('Geocoder error:', e);
+      }
+    }, 300);
+  }
+
+  onDestroy(() => {
+    clearTimeout(debounceTimer);
+    abortController?.abort();
+  });
+
+  let active = $derived(query !== '');
+  let statusMessage = $derived(
+    showDropdown ?
+      `${suggestions.length} result${suggestions.length === 1 ? '' : 's'} available`
+    : ''
+  );
+
+  function selectSuggestion(feature: GeocodeFeature) {
+    const { longitude: lng, latitude: lat } = feature.properties.coordinates;
+    query = feature.properties.name;
+    suggestions = [];
+    onselect?.({ lng, lat, name: feature.properties.name });
+  }
+
+  function clear() {
+    query = '';
+    suggestions = [];
+    inputEl?.focus();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (!showDropdown) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectedIndex = (selectedIndex + 1) % suggestions.length;
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectedIndex =
+        selectedIndex <= 0 ? suggestions.length - 1 : selectedIndex - 1;
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (selectedIndex >= 0) selectSuggestion(suggestions[selectedIndex]);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      suggestions = [];
+      selectedIndex = -1;
+    }
+  }
+</script>
+
+<div class="geocoder-input-wrapper">
+  <div class="geocoder-icon">
+    <MagnifyingGlass />
+  </div>
+  <input
+    bind:this={inputEl}
+    bind:value={query}
+    oninput={handleInput}
+    onkeydown={handleKeydown}
+    onfocus={() => (focused = true)}
+    onblur={() => (focused = false)}
+    type="text"
+    autocapitalize="words"
+    autocomplete="off"
+    enterkeyhint="search"
+    spellcheck="false"
+    role="combobox"
+    aria-expanded={showDropdown}
+    aria-label={searchPlaceholder}
+    aria-controls={showDropdown ? listboxId : undefined}
+    aria-activedescendant={selectedIndex >= 0 ?
+      `${listboxId}-option-${selectedIndex}`
+    : undefined}
+    aria-autocomplete="list"
+    placeholder={searchPlaceholder}
+    class="geocoder-input"
+  />
+  {#if active}
+    <button
+      class="geocoder-clear"
+      type="button"
+      aria-label="Clear search"
+      onmousedown={(e) => {
+        e.preventDefault();
+        clear();
+      }}
+    >
+      <X />
+    </button>
+  {/if}
+  <div class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+    {statusMessage}
+  </div>
+  {#if showDropdown}
+    <ul class="geocoder-results" role="listbox" id={listboxId}>
+      {#each suggestions as suggestion, i}
+        <li
+          id="{listboxId}-option-{i}"
+          role="option"
+          aria-selected={i === selectedIndex}
+          class:active={i === selectedIndex}
+          onmousedown={(e) => {
+            e.preventDefault();
+            selectSuggestion(suggestion);
+          }}
+          onmouseenter={() => (selectedIndex = i)}
+        >
+          {suggestion.properties.full_address || suggestion.properties.name}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use '../../scss/mixins' as mixins;
+
+  .geocoder-input-wrapper {
+    position: relative;
+    width: 100%;
+  }
+
+  .geocoder-icon {
+    position: absolute;
+    top: 50%;
+    left: 12px;
+    transform: translateY(-50%);
+    width: 22px;
+    height: 22px;
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .geocoder-clear {
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    transform: translateY(-50%);
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .geocoder-input {
+    font-family: var(--theme-font-family-sans-serif);
+    font-size: var(--theme-font-size-sm);
+    width: 100%;
+    height: 46px;
+    line-height: 22px;
+    padding: 12px 36px 12px 42px;
+    border: 1px solid mixins.$theme-colour-brand-rules;
+    border-radius: 0.25rem;
+    background: mixins.$theme-colour-background;
+    box-sizing: border-box;
+
+    &::placeholder {
+      color: mixins.$theme-colour-text-secondary;
+    }
+  }
+
+  .geocoder-results {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin: 4px 0 0;
+    padding: 0;
+    list-style: none;
+    background: mixins.$theme-colour-background;
+    border-radius: 0.25rem;
+    box-shadow: 0 2px 6px mixins.$theme-colour-brand-shadow;
+    z-index: 10000;
+    overflow: hidden;
+  }
+
+  .geocoder-results li {
+    padding: 10px 14px;
+    cursor: pointer;
+    font-family: var(--theme-font-family-sans-serif);
+    font-size: var(--theme-font-size-xs);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &.active {
+      background-color: var(--tr-hover-background-grey);
+    }
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (max-width: 767px) {
+    .geocoder-icon {
+      left: 10px;
+      width: 20px;
+      height: 20px;
+    }
+
+    .geocoder-input {
+      height: 42px;
+      font-size: var(--theme-font-size-xs);
+      padding: 10px 12px 10px 38px;
+      border-radius: 0.25rem;
+    }
+  }
+</style>

--- a/src/components/Geocoder/geocode.ts
+++ b/src/components/Geocoder/geocode.ts
@@ -1,0 +1,94 @@
+export type GeocodeFeatureType =
+  | 'country'
+  | 'region'
+  | 'postcode'
+  | 'district'
+  | 'place'
+  | 'locality'
+  | 'neighborhood'
+  | 'street'
+  | 'address';
+
+export interface GeocodeOptions {
+  /** Mapbox public access token. */
+  accessToken: string;
+  /** Return partial prefix matches (true) or exact matches only (false). Defaults to true. */
+  autocomplete?: boolean;
+  /** Limit results to a bounding box: [minLon, minLat, maxLon, maxLat]. Cannot cross the 180th meridian. */
+  bbox?: [number, number, number, number];
+  /** Filter results to one or more countries using ISO 3166-1 alpha-2 codes. */
+  country?: string[];
+  /** IETF language tags for the response. Also influences result scoring. Max 20. */
+  language?: string[];
+  /** Maximum number of results to return (1–10). Defaults to 5. */
+  limit?: number;
+  /** Bias results toward a location: [lon, lat] coordinates or 'ip' to use the request IP. */
+  proximity?: [number, number] | 'ip';
+  /** Filter results by feature type. */
+  types?: GeocodeFeatureType[];
+  /** Geopolitical worldview for boundary representation (e.g. 'us', 'cn', 'in'). Defaults to 'us'. */
+  worldview?: string;
+  /** Set to true if results will be stored/cached permanently. Defaults to false. */
+  permanent?: boolean;
+  /** Return building entrance data when available (public preview). Defaults to false. */
+  entrances?: boolean;
+}
+
+export interface GeocodeFeature {
+  type: 'Feature';
+  properties: {
+    mapbox_id: string;
+    feature_type: GeocodeFeatureType;
+    name: string;
+    name_preferred?: string;
+    place_formatted?: string;
+    full_address?: string;
+    coordinates: { longitude: number; latitude: number };
+    context: Record<
+      string,
+      { mapbox_id: string; name: string; [key: string]: unknown }
+    >;
+  };
+  geometry: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+}
+
+const BASE_URL = 'https://api.mapbox.com/search/geocode/v6/forward';
+
+export async function geocode(
+  query: string,
+  options: GeocodeOptions,
+  signal?: AbortSignal
+): Promise<GeocodeFeature[]> {
+  const params = new URLSearchParams({
+    q: query,
+    access_token: options.accessToken,
+  });
+
+  if (options.autocomplete !== undefined)
+    params.set('autocomplete', String(options.autocomplete));
+  if (options.bbox) params.set('bbox', options.bbox.join(','));
+  if (options.country) params.set('country', options.country.join(','));
+  if (options.language) params.set('language', options.language.join(','));
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+  if (options.proximity)
+    params.set(
+      'proximity',
+      Array.isArray(options.proximity) ?
+        options.proximity.join(',')
+      : options.proximity
+    );
+  if (options.types) params.set('types', options.types.join(','));
+  if (options.worldview) params.set('worldview', options.worldview);
+  if (options.permanent !== undefined)
+    params.set('permanent', String(options.permanent));
+  if (options.entrances !== undefined)
+    params.set('entrances', String(options.entrances));
+
+  const res = await fetch(`${BASE_URL}?${params}`, { signal });
+  if (!res.ok) throw new Error(`Geocode request failed: ${res.status}`);
+  const data = await res.json();
+  return data.features ?? [];
+}

--- a/src/components/TileMap/TileMap.stories.svelte
+++ b/src/components/TileMap/TileMap.stories.svelte
@@ -2,6 +2,7 @@
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import TileMap from './TileMap.svelte';
   import TileMapLayer from './TileMapLayer.svelte';
+  import Geocoder from '../Geocoder/Geocoder.svelte';
   import type { FeatureCollection, Polygon, Point } from 'geojson';
 
   // Example GeoJSON data - Central Park polygon
@@ -82,6 +83,12 @@
       },
     },
   });
+</script>
+
+<script lang="ts">
+  import type { Map as MapType } from 'maplibre-gl';
+  const mapboxAccessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? '';
+  let geocoderMapRef: MapType;
 </script>
 
 <Story
@@ -200,5 +207,31 @@
         'circle-stroke-color': '#ffffff',
       }}
     />
+  </TileMap>
+</Story>
+
+<Story name="With Geocoder" tags={['!autodocs']}>
+  <TileMap
+    id="geocoder-map"
+    center={[-98, 39]}
+    zoom={3}
+    interactive={true}
+    title="Map with Geocoder"
+    description="Search for a location to fly the map there."
+    height="500px"
+    onMapReady={(map) => {
+      geocoderMapRef = map;
+    }}
+  >
+    <div
+      style="position: absolute; top: 10px; left: 50%; transform: translateX(-50%); z-index: 1000; width: min(500px, calc(100% - 20px));"
+    >
+      <Geocoder
+        accessToken={mapboxAccessToken}
+        onselect={(loc) => {
+          geocoderMapRef?.flyTo({ center: [loc.lng, loc.lat], zoom: 10 });
+        }}
+      />
+    </div>
   </TileMap>
 </Story>

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export { default as DocumentCloud } from './components/DocumentCloud/DocumentClo
 export { default as EmbedPreviewerLink } from './components/EmbedPreviewerLink/EmbedPreviewerLink.svelte';
 export { default as FeaturePhoto } from './components/FeaturePhoto/FeaturePhoto.svelte';
 export { default as Framer } from './components/Framer/Framer.svelte';
+export { default as Geocoder } from './components/Geocoder/Geocoder.svelte';
+export { geocode } from './components/Geocoder/geocode';
 export { default as GraphicBlock } from './components/GraphicBlock/GraphicBlock.svelte';
 export { default as Headline } from './components/Headline/Headline.svelte';
 export { default as Headpile } from './components/Headpile/Headpile.svelte';
@@ -69,3 +71,9 @@ export type {
   HeadlineSize,
   ScrollerVideoInstance,
 } from './components/@types/global';
+
+export type {
+  GeocodeOptions,
+  GeocodeFeature,
+  GeocodeFeatureType,
+} from './components/Geocoder/geocode';


### PR DESCRIPTION
This PR adds a new **Geocoder** component to the library — an autocomplete location search box powered by the [Mapbox Geocoding v6 API](https://docs.mapbox.com/api/search/geocoding-v6/).

Users type a place name, get a dropdown of suggestions, and select one to get back coordinates and a display name via the `onselect` callback. It's the same pattern as the search box on mapbox.com or Google Maps.

The Mapbox access token stored as the `VITE_MAPBOX_ACCESS_TOKEN` env var and devs will need to add it to their .env file to use it. The key is in our 1Password.

I've added a GitHub secret for the token to be bundled with the Storybook instance, but I'm not 100% clear on how that will trickle down to `pnpm preview` and `pnpm upload`.

### What's included

- **Geocoder component** (`src/components/Geocoder/`) — fully accessible (ARIA combobox, keyboard nav, live region), debounced API calls, supports all Mapbox forward geocoding options (`country`, `language`, `types`, `bbox`, etc.)
- **Storybook demo** under Components/Controls/Geocoder with MDX docs
- **TileMap integration story** showing Geocoder overlaid on a map — selecting a location flies the map there
- **Library exports** for the component, the `geocode()` helper function, and TypeScript types
- **Changeset** (minor) for the release

### Usage

```svelte
<script>
  import { Geocoder } from '@reuters-graphics/graphics-components';

  function handleSelect(location) {
    console.log(location.name, location.lng, location.lat);
  }
</script>

<Geocoder accessToken={MAPBOX_TOKEN} onselect={handleSelect} />
```

The `accessToken` prop is required — look up the Reuters Mapbox token in the team's 1Password vault.

### Screenshots

**Geocoder standalone demo**

<img width="1318" height="1014" alt="Screenshot From 2026-05-06 15-36-42" src="https://github.com/user-attachments/assets/946a3727-6026-4ce9-adf4-d62781ef9acb" />

**TileMap with Geocoder integration**

<img width="1290" height="920" alt="Screenshot From 2026-05-06 15-36-23" src="https://github.com/user-attachments/assets/463d64ef-64c3-43db-ad17-66d7a8947fd3" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)