### PR TITLE
feat: add RPTA tracking primitives

### DIFF
--- a/.changeset/add-rpta-tracking.md
+++ b/.changeset/add-rpta-tracking.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Add RPTA tracking primitives: trackEvent, trackPageView, trackIdentity, and createTrackEvent

--- a/.gitignore
+++ b/.gitignore
@@ -188,7 +188,9 @@ dist
 
 # SvelteKit build / generate output
 .svelte-kit
+*storybook.log
+
+# Slop
+.claude
 
 # End of https://www.toptal.com/developers/gitignore/api/node,macos,linux
-
-*storybook.log

--- a/src/components/Analytics/Analytics.svelte
+++ b/src/components/Analytics/Analytics.svelte
@@ -26,15 +26,22 @@
   import { onMount } from 'svelte';
   import { ga, chartbeat } from './providers';
   import GoogleTagManager from './GTM.svelte';
+  import RPTALoader from './RPTALoader.svelte';
 
   interface Props {
     /**
      * Used to associate a page with its author(s) in Chartbeat.
      */
     authors?: Author[];
+    /**
+     * Enable RPTA event tracking via Segment. Loads the Segment analytics.js SDK
+     * and wires it to RPTA so that trackEvent, trackPageView, and trackIdentity
+     * calls are dispatched to downstream providers.
+     */
+    rpta?: boolean;
   }
 
-  let { authors = [] }: Props = $props();
+  let { authors = [], rpta = false }: Props = $props();
 
   onMount(() => {
     ga();
@@ -43,3 +50,6 @@
 </script>
 
 <GoogleTagManager />
+{#if rpta}
+  <RPTALoader />
+{/if}

--- a/src/components/Analytics/Analytics.svelte
+++ b/src/components/Analytics/Analytics.svelte
@@ -10,6 +10,12 @@
   }
 
   export { registerPageview };
+  export {
+    trackEvent,
+    trackPageView,
+    trackIdentity,
+    createTrackEvent,
+  } from './providers/rpta';
 </script>
 
 <script lang="ts">

--- a/src/components/Analytics/RPTA.mdx
+++ b/src/components/Analytics/RPTA.mdx
@@ -4,11 +4,23 @@ import * as RPTAStories from './RPTA.stories.svelte';
 
 <Meta of={RPTAStories} />
 
-# RPTA (Raptor Platform Tracking Analytics)
+# RPTA
 
-RPTA is the unified analytics layer on reuters.com. It dispatches events to downstream providers (Segment, Chartbeat, GTM, etc.) and is initialized by the platform before your code runs.
+The Raptor Platform Tracking Analytics (RPTA) is the unified analytics layer on reuters.com. It dispatches events to downstream providers via the Segment analytics.js module.
 
-These functions are low-level tools that any project can import and use directly, or wrap with project-specific defaults using `createTrackEvent`.
+The function documented here are low-level tools that any project can import and use directly, or wrap with project-specific defaults using `createTrackEvent`.
+
+## Setup
+
+To enable RPTA tracking, pass the `rpta` prop to the `Analytics` component. This loads the Segment SDK and wires it to RPTA so that tracking calls are dispatched to downstream providers.
+
+```svelte
+<script>
+  import { Analytics } from '@reuters-graphics/graphics-components';
+</script>
+
+<Analytics rpta />
+```
 
 ## Basic usage
 

--- a/src/components/Analytics/RPTA.mdx
+++ b/src/components/Analytics/RPTA.mdx
@@ -1,0 +1,85 @@
+import { Meta } from '@storybook/blocks';
+
+import * as RPTAStories from './RPTA.stories.svelte';
+
+<Meta of={RPTAStories} />
+
+# RPTA (Raptor Platform Tracking Analytics)
+
+RPTA is the unified analytics layer on reuters.com. It dispatches events to downstream providers (Segment, Chartbeat, GTM, etc.) and is initialized by the platform before your code runs.
+
+These functions are low-level tools that any project can import and use directly, or wrap with project-specific defaults using `createTrackEvent`.
+
+## Basic usage
+
+```typescript
+import { trackEvent } from '@reuters-graphics/graphics-components';
+
+trackEvent('ui.interaction', {
+  category: 'Article',
+  label: 'Read more clicked',
+  nonInteraction: 0,
+  uiInteraction: 1,
+  ui_element: 'read-more-button',
+});
+```
+
+## Creating a project-specific tracker
+
+Use `createTrackEvent` to build a wrapper that automatically includes default properties on every event. This is the recommended pattern for downstream projects that want consistent metadata on all their tracking calls.
+
+```typescript
+import { createTrackEvent } from '@reuters-graphics/graphics-components';
+
+// Create a tracker with defaults baked in
+const trackProjectEvent = createTrackEvent({
+  content_type: 'Interactive',
+  content_channel: 'Graphics',
+  topic_channel: 'World',
+  topic_sub_channel: 'Conflict',
+});
+```
+
+Then use it throughout your components:
+
+```typescript
+// Share button click
+trackProjectEvent('ui.interaction', {
+  category: 'My Project',
+  label: 'Share',
+  ui_element: 'share-icon',
+  nonInteraction: 0,
+  uiInteraction: 1,
+});
+
+// Carousel navigation
+trackProjectEvent('ui.interaction', {
+  category: 'My Project',
+  label: 'Next slide',
+  ui_element: 'carousel-arrow',
+  ui_element_position: 3,
+});
+```
+
+Per-call properties override defaults, so you can customize individual events as needed.
+
+## Page views and identity
+
+```typescript
+import {
+  trackPageView,
+  trackIdentity,
+} from '@reuters-graphics/graphics-components';
+
+// Track a virtual page view (e.g. after client-side navigation)
+trackPageView('Graphics', {
+  content_type: 'Interactive',
+});
+
+// Identify a user
+trackIdentity('user-abc-123');
+```
+
+## Environments
+
+These functions are production-gated automatically. They silently no-op on any hostname other than `reuters.com`, so you don't need to wrap them in environment checks.

--- a/src/components/Analytics/RPTA.stories.svelte
+++ b/src/components/Analytics/RPTA.stories.svelte
@@ -1,0 +1,9 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  const { Story } = defineMeta({
+    title: 'Components/Ads & analytics/RPTA',
+  });
+</script>
+
+<Story name="Demo" tags={['!autodocs', '!dev']} />

--- a/src/components/Analytics/RPTA.stories.svelte
+++ b/src/components/Analytics/RPTA.stories.svelte
@@ -4,6 +4,204 @@
   const { Story } = defineMeta({
     title: 'Components/Ads & analytics/RPTA',
   });
+
+  let logs = $state<string[]>([]);
+
+  function enableDebug() {
+    if (typeof window === 'undefined' || !window.rpta) return;
+    window.rpta.debug = true;
+  }
+
+  function fireTrackEvent() {
+    enableDebug();
+    window.rpta.trackEvent('ui.interaction', {
+      category: 'Test',
+      label: 'Button clicked',
+      ui_element: 'test-button',
+      nonInteraction: 0,
+      uiInteraction: 1,
+    });
+    logs = [
+      ...logs,
+      `trackEvent('ui.interaction', { category: 'Test', label: 'Button clicked' })`,
+    ];
+  }
+
+  function fireTrackPageView() {
+    enableDebug();
+    window.rpta.trackPageView('Graphics', {
+      content_type: 'Interactive',
+    });
+    logs = [
+      ...logs,
+      `trackPageView('Graphics', { content_type: 'Interactive' })`,
+    ];
+  }
+
+  function fireTrackIdentity() {
+    enableDebug();
+    window.rpta.trackIdentity('test-user-123');
+    logs = [...logs, `trackIdentity('test-user-123')`];
+  }
+
+  function clearLogs() {
+    logs = [];
+  }
 </script>
 
-<Story name="Demo" tags={['!autodocs', '!dev']} />
+<Story name="Demo" tags={['!autodocs']}>
+  {#await import('./Analytics.svelte') then { default: Analytics }}
+    <Analytics rpta />
+  {/await}
+
+  <div class="rpta-test">
+    <div class="rpta-test-panel">
+      <p class="rpta-test-kicker font-sans">RPTA test controls</p>
+      <p class="rpta-test-text font-sans">
+        These buttons call <code>window.rpta</code> methods directly, bypassing
+        the production gate. Open the browser console to see debug logs.
+      </p>
+      <div class="rpta-test-buttons">
+        <button class="rpta-test-btn" onclick={fireTrackEvent}>
+          trackEvent
+        </button>
+        <button class="rpta-test-btn" onclick={fireTrackPageView}>
+          trackPageView
+        </button>
+        <button class="rpta-test-btn" onclick={fireTrackIdentity}>
+          trackIdentity
+        </button>
+      </div>
+    </div>
+
+    {#if logs.length > 0}
+      <div class="rpta-test-log">
+        <div class="rpta-test-log-header">
+          <span class="rpta-test-log-title font-sans">Event log</span>
+          <button class="rpta-test-clear" onclick={clearLogs}>Clear</button>
+        </div>
+        <ul class="rpta-test-log-list">
+          {#each logs as log}
+            <li class="rpta-test-log-entry font-mono">{log}</li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+  </div>
+</Story>
+
+<style>
+  .rpta-test {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 36rem;
+  }
+
+  .rpta-test-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem;
+    border: 1px solid #d6dde8;
+    border-radius: 14px;
+    background: linear-gradient(180deg, #f8fbff 0%, #eef4ff 100%);
+  }
+
+  .rpta-test-kicker {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #315aa9;
+  }
+
+  .rpta-test-text {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.35;
+    color: #425466;
+  }
+
+  .rpta-test-text code {
+    background: #e2e8f0;
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+
+  .rpta-test-buttons {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .rpta-test-btn {
+    padding: 0.5rem 1rem;
+    border: 1px solid #315aa9;
+    border-radius: 6px;
+    background: white;
+    color: #315aa9;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+  }
+
+  .rpta-test-btn:hover {
+    background: #315aa9;
+    color: white;
+  }
+
+  .rpta-test-log {
+    border: 1px solid #d6dde8;
+    border-radius: 10px;
+    overflow: hidden;
+  }
+
+  .rpta-test-log-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    background: #f1f5f9;
+    border-bottom: 1px solid #d6dde8;
+  }
+
+  .rpta-test-log-title {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #64748b;
+  }
+
+  .rpta-test-clear {
+    font-size: 0.75rem;
+    color: #94a3b8;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .rpta-test-log-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .rpta-test-log-entry {
+    padding: 0.4rem 0.75rem;
+    font-size: 0.8rem;
+    color: #1e293b;
+    border-bottom: 1px solid #f1f5f9;
+  }
+
+  .rpta-test-log-entry:last-child {
+    border-bottom: none;
+  }
+</style>

--- a/src/components/Analytics/RPTALoader.svelte
+++ b/src/components/Analytics/RPTALoader.svelte
@@ -1,0 +1,102 @@
+<svelte:head>
+  <!-- Segment analytics.js -->
+  <link href="https://cdn.segment.com" rel="preconnect" />
+  <script>
+    window.analytics = window.analytics || [];
+    if (!window.analytics.initialize && !window.analytics.invoked) {
+      window.analytics.invoked = true;
+      window.analytics.methods = [
+        'trackSubmit',
+        'trackClick',
+        'trackLink',
+        'trackForm',
+        'pageview',
+        'identify',
+        'reset',
+        'group',
+        'track',
+        'ready',
+        'alias',
+        'debug',
+        'page',
+        'once',
+        'off',
+        'on',
+        'addSourceMiddleware',
+        'addIntegrationMiddleware',
+        'setAnonymousId',
+        'addDestinationMiddleware',
+      ];
+      window.analytics.factory = function (method) {
+        return function () {
+          var args = Array.prototype.slice.call(arguments);
+          args.unshift(method);
+          window.analytics.push(args);
+          return window.analytics;
+        };
+      };
+      for (var i = 0; i < window.analytics.methods.length; i++) {
+        var method = window.analytics.methods[i];
+        window.analytics[method] = window.analytics.factory(method);
+      }
+      window.analytics.load = function (writeKey, options) {
+        var script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.async = true;
+        script.src =
+          'https://cdn.segment.com/analytics.js/v1/' +
+          writeKey +
+          '/analytics.min.js';
+        var first = document.getElementsByTagName('script')[0];
+        first.parentNode.insertBefore(script, first);
+        window.analytics._loadOptions = options;
+      };
+      window.analytics.SNIPPET_VERSION = '4.15.2';
+      window.analytics.load('IEWBqQ8VWHijTQxb7lEBGFGS9uIJzigZ', {
+        integrations: { All: true, Chartbeat: false },
+      });
+    }
+  </script>
+  <!-- RPTA initialization -->
+  <script>
+    window.rpta = window.rpta || { cmd: [] };
+    var pending = window.rpta.cmd.slice();
+    window.rpta.debug = false;
+    window.rpta.trackEvent = function (name, props) {
+      if (window.rpta.debug)
+        console.log('%c rpta:trackEvent', 'color: seagreen', name, props);
+      window.analytics.track(name, props);
+    };
+    window.rpta.trackPageView = function (category, props) {
+      if (window.rpta.debug)
+        console.log(
+          '%c rpta:trackPageView',
+          'color: seagreen',
+          category,
+          props,
+        );
+      window.analytics.page(category, props);
+    };
+    window.rpta.trackIdentity = function (userId, props) {
+      if (window.rpta.debug)
+        console.log(
+          '%c rpta:trackIdentity',
+          'color: seagreen',
+          userId,
+          props,
+        );
+      if (userId) {
+        window.analytics.identify(userId, props);
+      } else {
+        window.analytics.identify(props);
+      }
+    };
+    window.rpta.executeCMD = function (cmds) {
+      cmds.forEach(function (fn) {
+        fn();
+      });
+    };
+    window.rpta.initialized = true;
+    window.rpta.executeCMD(pending);
+  </script>
+</svelte:head>

--- a/src/components/Analytics/providers/index.ts
+++ b/src/components/Analytics/providers/index.ts
@@ -1,2 +1,9 @@
 export { default as ga } from './ga';
 export { default as chartbeat } from './chartbeat';
+export {
+  trackEvent,
+  trackPageView,
+  trackIdentity,
+  createTrackEvent,
+} from './rpta';
+export type { RPTAEventProperties } from './rpta';

--- a/src/components/Analytics/providers/rpta.ts
+++ b/src/components/Analytics/providers/rpta.ts
@@ -1,0 +1,82 @@
+export interface RPTAEventProperties {
+  /** Event category grouping (e.g. "Article", "Video", "Subscription", "Markets") */
+  category?: string;
+  /** Human-readable label describing the event context (e.g. "Share", a URL, a video title) */
+  label?: string;
+  /** Set to 1 for events not triggered by user action (e.g. impressions). Default 0. */
+  nonInteraction?: number;
+  /** Set to 1 for events triggered by direct user interaction. Default 0. */
+  uiInteraction?: number;
+  /** Override the default event name sent downstream (e.g. "share.article.share", "save.article.save") */
+  analyticsEvent?: string;
+  /** Identifier for the UI element involved (e.g. "share-icon", "save-icon", "social share") */
+  ui_element?: string;
+  /** Label displayed on the UI element */
+  ui_element_label?: string;
+  /** Position of the element in a list or carousel (0-indexed or named) */
+  ui_element_position?: string | number;
+  /** Section of the page where the element appears (e.g. "Article Card", "Header") */
+  ui_element_location?: string;
+  /** Category of the UI element (e.g. "article") */
+  ui_element_category?: string;
+  /** Type of interaction performed (e.g. "share", "save", "unsave") */
+  ui_element_interaction?: string;
+  /** Type of content (e.g. "Landing Page") */
+  content_type?: string;
+  /** Primary content channel (e.g. "Climate") */
+  content_channel?: string;
+  /** Top-level topic channel */
+  topic_channel?: string;
+  /** Sub-channel within the topic */
+  topic_sub_channel?: string;
+  /** Canonical URL of the current page */
+  canonicalUrl?: string;
+  [key: string]: unknown;
+}
+
+function isReutersProduction() {
+  if (typeof window === 'undefined') return false;
+  const hostname = window.location?.hostname;
+  return hostname === 'www.reuters.com' || hostname === 'reuters.com';
+}
+
+function ensureRPTA() {
+  if (!isReutersProduction()) return false;
+  window.rpta = window.rpta || { cmd: [] };
+  return true;
+}
+
+export const trackEvent = (
+  eventName: string,
+  properties?: RPTAEventProperties
+) => {
+  if (!ensureRPTA()) return;
+  window.rpta.cmd.push(() => {
+    window.rpta.trackEvent(eventName, properties);
+  });
+};
+
+export const trackPageView = (
+  category: string,
+  properties?: RPTAEventProperties
+) => {
+  if (!ensureRPTA()) return;
+  window.rpta.cmd.push(() => {
+    window.rpta.trackPageView(category, properties);
+  });
+};
+
+export const trackIdentity = (
+  userId: string,
+  properties?: RPTAEventProperties
+) => {
+  if (!ensureRPTA()) return;
+  window.rpta.cmd.push(() => {
+    window.rpta.trackIdentity(userId, properties);
+  });
+};
+
+export const createTrackEvent =
+  (defaults: RPTAEventProperties) =>
+  (eventName: string, properties?: RPTAEventProperties) =>
+    trackEvent(eventName, { ...defaults, ...properties });

--- a/src/components/Analytics/providers/rpta.ts
+++ b/src/components/Analytics/providers/rpta.ts
@@ -37,7 +37,7 @@ export interface RPTAEventProperties {
 function isReutersProduction() {
   if (typeof window === 'undefined') return false;
   const hostname = window.location?.hostname;
-  return hostname === 'www.reuters.com' || hostname === 'reuters.com';
+  return hostname === 'reuters.com' || hostname?.endsWith('.reuters.com');
 }
 
 function ensureRPTA() {

--- a/src/components/Analytics/providers/rpta.ts
+++ b/src/components/Analytics/providers/rpta.ts
@@ -37,7 +37,11 @@ export interface RPTAEventProperties {
 function isReutersProduction() {
   if (typeof window === 'undefined') return false;
   const hostname = window.location?.hostname;
-  return hostname === 'reuters.com' || hostname?.endsWith('.reuters.com');
+  return (
+    hostname === 'reuters.com' ||
+    hostname?.endsWith('.reuters.com') ||
+    hostname === 'graphics.thomsonreuters.com'
+  );
 }
 
 function ensureRPTA() {
@@ -51,9 +55,13 @@ export const trackEvent = (
   properties?: RPTAEventProperties
 ) => {
   if (!ensureRPTA()) return;
-  window.rpta.cmd.push(() => {
+  if (window.rpta.initialized) {
     window.rpta.trackEvent(eventName, properties);
-  });
+  } else {
+    window.rpta.cmd.push(() => {
+      window.rpta.trackEvent(eventName, properties);
+    });
+  }
 };
 
 export const trackPageView = (
@@ -61,9 +69,13 @@ export const trackPageView = (
   properties?: RPTAEventProperties
 ) => {
   if (!ensureRPTA()) return;
-  window.rpta.cmd.push(() => {
+  if (window.rpta.initialized) {
     window.rpta.trackPageView(category, properties);
-  });
+  } else {
+    window.rpta.cmd.push(() => {
+      window.rpta.trackPageView(category, properties);
+    });
+  }
 };
 
 export const trackIdentity = (
@@ -71,9 +83,13 @@ export const trackIdentity = (
   properties?: RPTAEventProperties
 ) => {
   if (!ensureRPTA()) return;
-  window.rpta.cmd.push(() => {
+  if (window.rpta.initialized) {
     window.rpta.trackIdentity(userId, properties);
-  });
+  } else {
+    window.rpta.cmd.push(() => {
+      window.rpta.trackIdentity(userId, properties);
+    });
+  }
 };
 
 export const createTrackEvent =

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -21,9 +21,17 @@ declare global {
     };
     /** Graphics ads */
     graphicsAdQueue: any[];
+    /** Segment analytics.js */
+    analytics: {
+      track: (event: string, properties?: Record<string, unknown>) => void;
+      page: (category: string, properties?: Record<string, unknown>) => void;
+      identify: (...args: unknown[]) => void;
+      [key: string]: unknown;
+    };
     /** Raptor Platform Tracking Analytics */
     rpta: {
       initialized?: boolean;
+      debug?: boolean;
       cmd: Array<() => void>;
       trackEvent: (
         eventName: string,

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -21,6 +21,24 @@ declare global {
     };
     /** Graphics ads */
     graphicsAdQueue: any[];
+    /** Raptor Platform Tracking Analytics */
+    rpta: {
+      initialized?: boolean;
+      cmd: Array<() => void>;
+      trackEvent: (
+        eventName: string,
+        properties?: Record<string, unknown>
+      ) => void;
+      trackPageView: (
+        category: string,
+        properties?: Record<string, unknown>
+      ) => void;
+      trackIdentity: (
+        userId: string,
+        properties?: Record<string, unknown>
+      ) => void;
+      executeCMD: (cmds: Array<() => void>) => void;
+    };
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ export { prettifyDate, getAuthorPageUrl, formatTime } from './utils/index';
 export {
   default as Analytics,
   registerPageview,
+  trackEvent,
+  trackPageView,
+  trackIdentity,
+  createTrackEvent,
 } from './components/Analytics/Analytics.svelte';
+export type { RPTAEventProperties } from './components/Analytics/providers/rpta';
 export { default as Article } from './components/Article/Article.svelte';
 export { default as BlogPost } from './components/BlogPost/BlogPost.svelte';
 export { default as BlogTOC } from './components/BlogTOC/BlogTOC.svelte';


### PR DESCRIPTION
## Summary

- Adds `trackEvent`, `trackPageView`, `trackIdentity`, and `createTrackEvent` as reusable functions for interacting with Reuters' RPTA (Raptor Platform Tracking Analytics) layer
- Functions are automatically production-gated to `reuters.com` hostnames — they silently no-op elsewhere, so consumers don't need environment checks
- `createTrackEvent` is a factory that returns a pre-configured `trackEvent` with default properties baked in, enabling downstream projects to build project-specific tracking wrappers
- Includes Storybook documentation under "Components/Ads & analytics/RPTA"

## Test plan

- [x] `pnpm build` passes with `publint` validation
- [x] `pnpm check` passes with 0 errors and 0 warnings
- [x] Verify Storybook docs render correctly at the RPTA entry
- [ ] Verify tracking functions fire correctly on reuters.com production

🤖 Generated with [Claude Code](https://claude.com/claude-code)