### PR TITLE
Refactor styles and add ArcRendering component (#421)

### DIFF
--- a/.storybook/Wrapper.svelte
+++ b/.storybook/Wrapper.svelte
@@ -5,8 +5,10 @@
   import 'prism-themes/themes/prism-nord.css';
 </script>
 
-<Theme>
-  <Article>
-    <slot />
-  </Article>
-</Theme>
+<div id="reuters-graphics-svelte-app">
+  <Theme>
+    <Article>
+      <slot />
+    </Article>
+  </Theme>
+</div>

--- a/src/components/ArcRendering/ArcRendering.mdx
+++ b/src/components/ArcRendering/ArcRendering.mdx
@@ -1,0 +1,64 @@
+import { Meta, Canvas } from '@storybook/blocks';
+
+import * as ArcRenderingStories from './ArcRendering.stories.svelte';
+
+<Meta of={ArcRenderingStories} />
+
+# ArcRendering
+
+The `ArcRendering` component configures how a page is rendered when published on reuters.com.
+
+It does two things:
+
+1. Sets a Svelte context (`arcxp:renderMode`) so descendant components can detect whether they are being rendered inside the reuters.com shell or standalone.
+2. Injects a JSON-LD `<script>` tag into the document `<head>` containing metadata that Arc XP uses to show the Reuters Header and Footer, paywall status and leaderboard ad.
+
+
+
+
+> **Note:** Don't use this component for embed pages.
+
+## Props
+
+- **`shell`** (`boolean`, default `true`) — When `true`, the page is wrapped in the reuters.com shell (site header, navigation and footer). Set to `false` for standalone embeds or legacy graphics.
+- **`paywall`** (`boolean`, default `false`) — When `true`, marks the page as paywalled (`isAccessibleForFree: false` in the JSON-LD).
+- **`leaderboardAd`** (`boolean`, default `true`) — When `false`, suppresses the leaderboard ad on the page.
+
+
+```svelte
+<script>
+  import { ArcRendering, Theme } from '@reuters-graphics/graphics-components';
+</script>
+
+<Theme base="light">
+  <ArcRendering shell={true} paywall={true} leaderboardAd={true}>
+   <!-- page content -->
+  </ArcRendering>
+</Theme>
+```
+
+{/* <Canvas of={ArcRenderingStories.Default} /> */}
+
+
+When rendered inside the shell, it adds the header and footer from dotcom by default. If you need to use the legacy furniture, import them directly into your page.svelte
+
+```svelte
+<script>
+  import { ArcRendering, Theme } from '@reuters-graphics/graphics-components';
+  import { isReutersApp } from '$utils/env';
+</script>
+
+<Theme base="light">
+  {#if !isReutersApp(page.url)}
+    <SiteHeader />
+  {/if}
+
+  <ArcRendering shell={false} paywall={true} leaderboardAd={true}>
+   <!-- page content -->
+  </ArcRendering>
+
+  {#if !isReutersApp(page.url)}
+    <SiteFooter />
+  {/if}
+</Theme>
+```

--- a/src/components/ArcRendering/ArcRendering.stories.svelte
+++ b/src/components/ArcRendering/ArcRendering.stories.svelte
@@ -1,0 +1,29 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import ArcRendering from './ArcRendering.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Components/Page furniture/ArcRendering',
+    component: ArcRendering,
+    argTypes: {
+      shell: { control: 'boolean' },
+      paywall: { control: 'boolean' },
+      leaderboardAd: { control: 'boolean' },
+    },
+  });
+</script>
+
+<Story
+  name="Default"
+  args={{
+    shell: true,
+    paywall: false,
+    leaderboardAd: true,
+  }}
+>
+  {#snippet children(args)}
+    <ArcRendering {...args}>
+      <p>Page content rendered inside the reuters.com shell.</p>
+    </ArcRendering>
+  {/snippet}
+</Story>

--- a/src/components/ArcRendering/ArcRendering.svelte
+++ b/src/components/ArcRendering/ArcRendering.svelte
@@ -1,0 +1,69 @@
+<!-- @component
+  `ArcRendering` configures how a page is rendered when published on reuters.com.
+
+  It sets a render-mode context for child components and injects a JSON-LD
+  `<script>` tag into the document head with metadata that Arc XP reads to
+  determine how to wrap, paywall and monetise the page.
+
+  [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-page-furniture-arcrendering--docs)
+-->
+<script lang="ts">
+  import { setContext } from 'svelte';
+
+  interface Props {
+    /**
+     * Whether to wrap the page in the reuters.com shell (site header,
+     * navigation and footer). When `false`, the page renders without the
+     * shell — useful for standalone embeds or legacy graphics.
+     * @default true
+     */
+    shell?: boolean;
+    /**
+     * Whether the page's content sits behind the Reuters paywall. When
+     * `true`, the page is flagged as not accessible for free in the
+     * JSON-LD metadata.
+     * @default false
+     */
+    paywall?: boolean;
+    /**
+     * Whether to display the leaderboard ad at the top of the page. Set
+     * to `false` to suppress the leaderboard ad on this page.
+     * @default true
+     */
+    leaderboardAd?: boolean;
+    /**
+     * Page content rendered inside this component.
+     */
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    shell = true,
+    paywall = false,
+    leaderboardAd = true,
+    children,
+  }: Props = $props();
+
+  // Expose the active render mode to descendant components via Svelte
+  // context, so they can adapt their behaviour when rendered inside the
+  // reuters.com shell vs. standalone.
+  setContext('arcxp:renderMode', () => (shell ? 'reuters' : ''));
+
+  // JSON-LD payload consumed by Arc XP to control page-level rendering
+  // behaviour: which shell to use, paywall status and ad suppression.
+  let arcLdJson = $derived({
+    'arcxp:renderMode': shell ? 'reuters' : '',
+    isAccessibleForFree: !paywall,
+    'arcxp:noLeaderboardAd': !leaderboardAd,
+  });
+</script>
+
+<svelte:head>
+  <!-- Inject Arc XP render-configuration metadata into the document head.
+       The `script` tag is split to prevent Svelte from parsing it as a
+       real script element during SSR. -->
+  <!-- svelte-ignore hydration_html_changed -->
+  {@html `<${'script'} type="application/ld+json">${JSON.stringify(arcLdJson)}</script>`}
+</svelte:head>
+
+{@render children?.()}

--- a/src/components/Article/Article.svelte
+++ b/src/components/Article/Article.svelte
@@ -13,7 +13,9 @@
     wider: number;
   }
 
+  import { getContext } from 'svelte';
   import cssVariables from '../../actions/cssVariables/index';
+
   interface Props {
     /** Set to true for embeddables. */
     embedded?: boolean;
@@ -40,6 +42,35 @@
     children,
   }: Props = $props();
 
+  // Read the render-mode getter set by an ancestor `<ArcRendering>` via
+  // Svelte context. It returns `'reuters'` when the page is configured to
+  // render inside the reuters.com Arc shell, and an empty string otherwise.
+  // The context is absent on pages that don't use `<ArcRendering>` at all
+  // (e.g. standalone embeds, Storybook, legacy graphics).
+  const getRenderMode =
+    getContext<() => string | undefined>('arcxp:renderMode');
+
+  // Detect whether the page is actually being served from reuters.com. We
+  // gate the <main>-skipping behaviour on this so that local dev, preview
+  // builds and Storybook still render their own <main> landmark — only the
+  // production Arc shell provides one for us.
+  const onReutersDotcom =
+    typeof window !== 'undefined' &&
+    (window.location.hostname === 'reuters.com' ||
+      window.location.hostname === 'www.reuters.com');
+
+  // Skip wrapping in <main> only when BOTH conditions are true:
+  //   1. An ancestor `<ArcRendering>` set renderMode to `'reuters'`, AND
+  //   2. We're actually running on reuters.com.
+  // In that case Arc XP's shell already provides the page's <main> landmark,
+  // and rendering another would produce two <main> elements in the document.
+  // In every other case (no context, non-reuters render mode, or off-domain),
+  // we render our own <main id="main-content"> so the page has a proper
+  // landmark for accessibility and skip-links.
+  let wrapInMain = $derived(
+    !getRenderMode || getRenderMode() !== 'reuters' || !onReutersDotcom
+  );
+
   let columnWidthVars = $derived({
     'narrower-column-width': columnWidths.narrower + 'px',
     'narrow-column-width': columnWidths.narrow + 'px',
@@ -49,12 +80,22 @@
   });
 </script>
 
-<main id="main-content">
+{#if wrapInMain}
+  <!-- Default: render our own <main> landmark for the page. -->
+  <main id="main-content">
+    <article {id} class:embedded {role} use:cssVariables={columnWidthVars}>
+      <!-- Article content -->
+      {@render children?.()}
+    </article>
+  </main>
+{:else}
+  <!-- Inside the reuters.com Arc shell: the shell already renders <main>,
+       so we only emit the <article> to avoid nesting/duplicate landmarks. -->
   <article {id} class:embedded {role} use:cssVariables={columnWidthVars}>
     <!-- Article content -->
     {@render children?.()}
   </article>
-</main>
+{/if}
 
 <style lang="scss">
   article {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {
   default as Analytics,
   registerPageview,
 } from './components/Analytics/Analytics.svelte';
+export { default as ArcRendering } from './components/ArcRendering/ArcRendering.svelte';
 export { default as Article } from './components/Article/Article.svelte';
 export { default as BlogPost } from './components/BlogPost/BlogPost.svelte';
 export { default as BlogTOC } from './components/BlogTOC/BlogTOC.svelte';

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -6,10 +6,26 @@
  * Copyright 2023 Reuters Graphics Style Guide
  */
 
-// Base style rules
-@use 'reset/main' as reset;
+// Truly global — baseline reset & fonts at the stylesheet root
+@use 'reset/normalize';
 @use 'fonts/font-faces' as font-faces;
+
+// Element-level rules scoped to the app wrapper
+@use 'reset/main' as reset;
+@use 'reset/typography' as typography;
+
+// Class-based utilities
+@use 'token-classes' as *;
+
+// Colour palette
 @use 'colours/main' as colours;
 
-// Token classes
-@use 'token-classes' as *;
+// Root styles
+@include reset.root-styles;
+@include typography.root-styles;
+
+// Scoped styles
+#reuters-graphics-svelte-app {
+  @include reset.scoped-styles;
+  @include typography.scoped-styles;
+}

--- a/src/scss/reset/_main.scss
+++ b/src/scss/reset/_main.scss
@@ -1,40 +1,53 @@
 @use '../mixins' as *;
-@forward 'normalize';
-@forward 'typography';
 
-*,
-*:before,
-*:after {
-  box-sizing: border-box;
-}
-
-body {
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-
-  .theme {
-    ::selection {
-      background-color: $theme-colour-text-secondary;
-      color: $theme-colour-background;
-    }
+// Applies to entire page — safe at root
+@mixin root-styles {
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
   }
 }
 
-img,
-video {
-  display: block;
-}
+// Applies to elements scoped to #reuters-graphics-svelte-app
+@mixin scoped-styles {
+  // Disable the grey tap highlight on touch devices for the scoped app.
+  -webkit-tap-highlight-color: transparent;
 
-img {
-  max-width: 100%;
-  @include fmy-6;
-}
+  // Text selection highlight
+  .theme ::selection {
+    background-color: var(
+      --theme-colour-text-secondary,
+      #{$theme-colour-text-secondary}
+    );
+    color: var(--theme-colour-background, #{$theme-colour-background});
+  }
 
-figure {
-  @include fmy-6;
-  @include fmx-auto;
-}
+  img,
+  svg,
+  video,
+  canvas,
+  picture {
+    display: block;
+  }
 
-iframe:not([id^='google_ads_iframe_']) {
-  border: 0;
-  width: 100%;
+  img {
+    max-width: 100%;
+    height: auto; // preserve aspect ratio when width attribute is set
+  }
+
+  img,
+  figure {
+    @include fmy-6;
+  }
+
+  figure {
+    @include fmx-auto;
+  }
+
+  // Don't override Google Ad iframes, which set their own dimensions.
+  iframe:not([id^='google_ads_iframe_']) {
+    border: 0;
+    width: 100%;
+  }
 }

--- a/src/scss/reset/_typography.scss
+++ b/src/scss/reset/_typography.scss
@@ -1,155 +1,169 @@
 @use '../mixins' as *;
 
-html {
-  font-size: 100%;
+// Applies to entire page — safe at root
+@mixin root-styles {
+  html {
+    font-size: 100%;
+
+    // Font-smoothing
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 }
 
-body {
-  font-size: 1rem;
-  color: #404040;
+// Applies elements scoped to #reuters-graphics-svelte-app
+@mixin scoped-styles {
   @include font-knowledge;
   @include font-regular;
   @include leading-tight;
-
-  // Font-smoothing
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font-size: 1rem;
+  color: $theme-colour-text-primary;
 
   .theme {
-    font-size: calc(0.9 * var(--theme-font-size-base));
-    color: var(--theme-colour-text-primary);
     @include font-sans;
+    // Theme blocks render at 90% of the host page's base font size
+    // so embedded graphics sit slightly smaller than surrounding body copy.
+    font-size: calc(0.9 * var(--theme-font-size-base));
+    color: var(--theme-colour-text-primary, #{$theme-colour-text-primary});
   }
-}
 
-// SIZE RANGE REFERENCE //
-// xxs: 12.64px
-// xs: 14.22px
-// sm: 16.00px → 16.80px
-// base: 18.00px → 21.00px
-// lg: 20.25px → 26.25px
-// xl: 22.78px → 32.81px
-// 2xl: 25.63px → 41.02px
-// 3xl: 28.83px → 51.27px
-// 4xl: 32.44px → 64.09px
-// 5xl: 36.49px → 80.11px
-// 6xl: 41.05px → 100.14px
+  // SIZE RANGE REFERENCE //
+  // xxs: 12.64px
+  // xs: 14.22px
+  // sm: 16.00px → 16.80px
+  // base: 18.00px → 21.00px
+  // lg: 20.25px → 26.25px
+  // xl: 22.78px → 32.81px
+  // 2xl: 25.63px → 41.02px
+  // 3xl: 28.83px → 51.27px
+  // 4xl: 32.44px → 64.09px
+  // 5xl: 36.49px → 80.11px
+  // 6xl: 41.05px → 100.14px
 
-/////////////
-// HEADINGS
-/////////////
+  /////////////
+  // HEADINGS
+  /////////////
 
-h1 {
-  @include h1;
-}
+  h1 {
+    @include h1;
+  }
 
-h2 {
-  @include h2;
-}
+  h2 {
+    @include h2;
+  }
 
-h3 {
-  @include h3;
-}
+  h3 {
+    @include h3;
+  }
 
-h4,
-h5,
-h6 {
-  @include h4;
-}
+  h4,
+  h5,
+  h6 {
+    @include h4;
+  }
 
-//////////////
-// Body text
-//////////////
+  //////////////
+  // Body text
+  //////////////
 
-text {
-  @include body-note;
-}
+  // <text> is an SVG element — applies body-note styling
+  // to text rendered inside charts and visualizations.
+  svg text {
+    @include body-note;
+  }
 
-p {
-  display: block;
-  @include body-text;
-}
-
-ol,
-ul {
-  display: block;
-  @include body-text;
-  @include fmb-6;
-  @include fpl-4;
-  list-style-position: outside;
+  p {
+    @include body-text;
+  }
 
   ol,
   ul {
+    @include body-text;
+    @include fmb-6;
     @include fpl-4;
-    @include fmb-2;
+    list-style-position: outside;
+
+    ol,
+    ul {
+      @include fpl-4;
+      @include fmb-2;
+    }
+
+    li {
+      @include fmy-1;
+
+      &::marker {
+        @include font-light;
+        @include font-note;
+        @include text-sm;
+        @include text-secondary;
+      }
+    }
   }
 
-  li {
-    @include fmy-1;
+  ul {
+    list-style-type: disc;
   }
 
-  li::marker {
-    @include font-light;
-    @include font-note;
+  ol {
+    list-style-type: decimal;
+  }
+
+  a {
+    @include body-link;
+  }
+
+  em {
+    font-style: italic;
+  }
+
+  strong {
+    @include font-bold;
+  }
+
+  pre,
+  code,
+  kbd {
+    @include font-mono;
     @include text-sm;
     @include text-secondary;
+    @include fmx-0;
+    @include fmt-0;
+    @include fmb-3;
   }
-}
 
-ul {
-  list-style-type: disc;
-}
-
-a {
-  @include body-link;
-}
-
-em {
-  font-style: italic;
-}
-
-strong {
-  @include font-bold;
-}
-
-pre,
-code,
-kbd {
-  @include font-mono;
-  @include text-sm;
-  @include text-secondary;
-  @include fmx-0;
-  @include fmt-0;
-  @include fmb-3;
-}
-
-kbd {
-  background-color: $theme-colour-text-primary;
-  color: $theme-colour-background;
-  border-radius: 0.3rem;
-  @include fpx-2;
-  @include fpy-1;
-}
-
-figcaption {
-  @include body-caption;
-  @include fmb-0;
-}
-
-blockquote {
-  @include fmx-0;
-  @include fmy-6;
-  p {
-    @include body-note;
-    @include font-light;
-    @include text-lg;
+  kbd {
+    @include fpx-2;
+    @include fpy-1;
+    background-color: $theme-colour-text-primary;
+    color: $theme-colour-background;
+    border-radius: 0.3rem;
   }
+
+  figcaption {
+    @include body-caption;
+    @include fmb-0;
+  }
+
   blockquote {
-    @include fmt-3;
+    @include fmx-0;
+    @include fmy-6;
+
     p {
-      @include body-caption;
-      @include text-sm;
-      @include fmb-0;
+      @include body-note;
+      @include font-light;
+      @include text-lg;
+    }
+
+    // Nested blockquote = attribution / sub-quote, rendered smaller.
+    blockquote {
+      @include fmt-3;
+
+      p {
+        @include body-caption;
+        @include text-sm;
+        @include fmb-0;
+      }
     }
   }
 }


### PR DESCRIPTION
### What's in this pull request

Refactors the SCSS reset and typography layers and introduces the new `ArcRendering` component. Addresses issue #421 and follows on from #420.

**Style refactoring** (`src/scss/reset/_typography.scss`, `src/scss/reset/_main.scss`, `src/scss/main.scss`):

- Replaced hardcoded `#404040` with the `$theme-colour-text-primary` design token for consistent theming.
- Made the SVG `text` selector explicit (`svg text`) and documented intent — it now clearly targets chart/visualization text rather than colliding with the HTML namespace.
- Removed redundant `display: block` declarations on `p`, `ol`, `ul` (block-level by default).
- Consolidated cascade fragmentation: nested `li::marker` inside `li` using `&::marker`; grouped `list-style-type` rules and made `ol` explicit.
- Standardized `@include` ordering (mixins → properties → nested selectors) across `.theme`, `kbd`, and the typography root.
- Added clarifying comments on the `0.9` font-size multiplier and the nested-blockquote pattern.
- Moved font-smoothing declarations from scoped to root-level for global coverage.

**New `ArcRendering` component** (`src/components/ArcRendering/`):

- Component, stories and MDX docs for rendering Arc-shell pages.
- `Article` updated to conditionally skip the `<main>` wrapper when inside an Arc shell.
- Storybook `Wrapper` updated to support the new rendering path.

### Before submitting, please check that you've

- [x] Read our [contributing guide](https://github.com/reuters-graphics/graphics-components/blob/master/CONTRIBUTING.md)
- [x] Documented any new components or features (`ArcRendering.mdx`)
- [ ] Tagged an editor to review this PR
