### PR TITLE
Add screenshot-embeds agent skill

### DIFF
--- a/.agents/skills/screenshot-embeds/SKILL.md
+++ b/.agents/skills/screenshot-embeds/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: screenshot-embeds
+description: >
+  Take screenshots of all embed pages and save them as share images.
+  Use when the user asks to update, regenerate, or take embed screenshots,
+  or when new embed pages have been added.
+compatibility: >
+  Requires Node.js 20+ and a Chrome or Chromium binary (Puppeteer cache,
+  google-chrome-stable, or chromium on PATH). The puppeteer-core npm
+  package is installed automatically to /tmp on first run if not present.
+---
+
+# Screenshot Embeds
+
+Captures a screenshot of every embed page in a graphics-kit project and
+saves the images to `src/statics/images/embed-{name}.png` for use as
+share images in the CMS asset picker.
+
+## Requirements
+
+The bundled script (`scripts/screenshot.mjs`) self-provisions its
+dependencies at runtime:
+
+- **Node.js 20+** — must be available as `node`
+- **Chrome / Chromium** — discovered automatically from the Puppeteer
+  cache (`~/.cache/puppeteer/chrome/`) or the system PATH
+  (`google-chrome-stable`, `google-chrome`, `chromium`)
+- **puppeteer-core** — if not already installed, the script runs
+  `npm install --prefix /tmp puppeteer-core` so it never modifies the
+  project's own `node_modules`
+
+No manual setup is needed on a machine that already has Chrome installed.
+
+## Steps
+
+1. Run the script from the project root:
+
+   ```bash
+   node .agents/skills/screenshot-embeds/scripts/screenshot.mjs
+   ```
+
+   You can pass custom viewport sizes per embed as JSON:
+
+   ```bash
+   node .agents/skills/screenshot-embeds/scripts/screenshot.mjs \
+     --viewports '{"homepage-strip": {"width": 600, "height": 600}}'
+   ```
+
+2. The script will:
+   - Discover all embed pages under `pages/embeds/en/`
+   - Start the Vite dev server
+   - Screenshot each embed with an appropriate viewport size
+   - Save the images and stop the server
+
+3. After the script finishes, display each generated screenshot to the user
+   for visual review using the Read tool on the PNG files in
+   `src/statics/images/embed-*.png`.
+
+4. For any new embed whose `<SEO>` component still references the generic
+   placeholder image, update the `shareImgPath` prop to point to the new
+   screenshot. Each embed page lives at `pages/embeds/en/{name}/+page.svelte`
+   and contains a `<SEO>` component. The prop should follow this pattern:
+
+   ```svelte
+   shareImgPath="{assets}/images/embed-{name}.png"
+   ```
+
+   Where `{name}` matches the embed directory name (e.g. `globe`,
+   `homepage-strip`). Look for any `shareImgPath` that still points to
+   `reuters-graphics.jpg` and replace it. Embeds that already reference
+   their own `embed-*.png` image can be left alone.

--- a/.agents/skills/screenshot-embeds/scripts/screenshot.mjs
+++ b/.agents/skills/screenshot-embeds/scripts/screenshot.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+/**
+ * Screenshots every embed page and saves the images as share images.
+ *
+ * Usage:  node .agents/skills/screenshot-embeds/scripts/screenshot.mjs
+ *
+ * Options:
+ *   --viewports '{"my-embed": {"width": 800, "height": 600}}'
+ *       Override the default viewport size for specific embeds.
+ *
+ * Requirements:
+ *   - A Chrome/Chromium binary (Puppeteer cache or system PATH)
+ *   - puppeteer-core (installed to /tmp on demand if missing)
+ */
+
+import { execSync, spawn } from 'node:child_process';
+import { readdirSync, statSync, existsSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+import { createRequire } from 'node:module';
+import { parseArgs } from 'node:util';
+
+const PROJECT_ROOT = resolve(import.meta.dirname, '..', '..', '..', '..');
+const EMBEDS_DIR = resolve(PROJECT_ROOT, 'pages/embeds/en');
+const IMAGES_DIR = resolve(PROJECT_ROOT, 'src/statics/images');
+const PORT = 5199;
+const BASE = `http://localhost:${PORT}`;
+
+const DEFAULT_VIEWPORT = { width: 800, height: 600 };
+
+// ---------------------------------------------------------------------------
+// Parse CLI args
+// ---------------------------------------------------------------------------
+
+const { values: args } = parseArgs({
+  options: {
+    viewports: { type: 'string', default: '{}' },
+  },
+  strict: false,
+});
+
+let customViewports = {};
+try {
+  customViewports = JSON.parse(args.viewports);
+} catch {
+  console.error('Warning: could not parse --viewports JSON, using defaults.');
+}
+
+// ---------------------------------------------------------------------------
+// Discover embeds
+// ---------------------------------------------------------------------------
+
+function discoverEmbeds() {
+  if (!existsSync(EMBEDS_DIR)) {
+    console.error(`Embeds directory not found: ${EMBEDS_DIR}`);
+    process.exit(1);
+  }
+  return readdirSync(EMBEDS_DIR)
+    .filter((name) => {
+      const dir = resolve(EMBEDS_DIR, name);
+      return (
+        statSync(dir).isDirectory() &&
+        existsSync(resolve(dir, '+page.svelte'))
+      );
+    })
+    .map((name) => ({
+      name,
+      path: `/embeds/en/${name}/`,
+      ...(customViewports[name] || DEFAULT_VIEWPORT),
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Find a Chrome binary
+// ---------------------------------------------------------------------------
+
+function findChrome() {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const cacheDir = resolve(home, '.cache/puppeteer/chrome');
+  if (existsSync(cacheDir)) {
+    const versions = readdirSync(cacheDir).sort();
+    for (const ver of versions.reverse()) {
+      const bin = resolve(cacheDir, ver, 'chrome-linux64/chrome');
+      if (existsSync(bin)) return bin;
+    }
+  }
+  for (const name of ['google-chrome-stable', 'google-chrome', 'chromium']) {
+    try {
+      const p = execSync(`which ${name}`, { encoding: 'utf8' }).trim();
+      if (p) return p;
+    } catch {
+      // not found
+    }
+  }
+  throw new Error('No Chrome binary found. Install Chrome or Puppeteer.');
+}
+
+// ---------------------------------------------------------------------------
+// Ensure puppeteer-core is available
+// ---------------------------------------------------------------------------
+
+async function loadPuppeteer() {
+  const require = createRequire(import.meta.url);
+  try {
+    return require('puppeteer-core');
+  } catch {
+    // not in project deps — install to /tmp
+  }
+  const tmpPkg = '/tmp/node_modules/puppeteer-core';
+  if (!existsSync(tmpPkg)) {
+    console.log('Installing puppeteer-core to /tmp ...');
+    execSync('npm install --prefix /tmp puppeteer-core', { stdio: 'inherit' });
+  }
+  return require('/tmp/node_modules/puppeteer-core');
+}
+
+// ---------------------------------------------------------------------------
+// Dev server helpers
+// ---------------------------------------------------------------------------
+
+function startDevServer() {
+  return new Promise((resolve, reject) => {
+    const child = spawn('npx', ['vite', 'dev', '--port', String(PORT)], {
+      cwd: PROJECT_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let started = false;
+    const onData = (chunk) => {
+      const text = chunk.toString();
+      if (!started && text.includes('Local:')) {
+        started = true;
+        resolve(child);
+      }
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.on('error', reject);
+    setTimeout(() => {
+      if (!started) reject(new Error('Dev server did not start within 30s'));
+    }, 30000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const embeds = discoverEmbeds();
+if (embeds.length === 0) {
+  console.log('No embed pages found.');
+  process.exit(0);
+}
+
+console.log(`Found ${embeds.length} embed(s): ${embeds.map((e) => e.name).join(', ')}`);
+
+const chromePath = findChrome();
+console.log(`Using Chrome: ${chromePath}`);
+
+const puppeteer = await loadPuppeteer();
+
+console.log('Starting dev server ...');
+const server = await startDevServer();
+console.log(`Dev server ready on port ${PORT}`);
+
+const browser = await puppeteer.launch({
+  executablePath: chromePath,
+  headless: true,
+  args: ['--no-sandbox', '--disable-setuid-sandbox'],
+});
+
+try {
+  for (const embed of embeds) {
+    console.log(`  Screenshotting ${embed.name} (${embed.width}x${embed.height}) ...`);
+    const page = await browser.newPage();
+    await page.setViewport({ width: embed.width, height: embed.height });
+    await page.goto(`${BASE}${embed.path}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 30000,
+    });
+
+    try {
+      await page.waitForSelector('canvas.maplibregl-canvas, svg', {
+        timeout: 20000,
+      });
+    } catch {
+      // embed may not have a map or chart
+    }
+    await new Promise((r) => setTimeout(r, 6000));
+
+    const outPath = resolve(IMAGES_DIR, `embed-${embed.name}.png`);
+    await page.screenshot({ path: outPath });
+    console.log(`    Saved ${basename(outPath)}`);
+    await page.close();
+  }
+} finally {
+  await browser.close();
+  server.kill();
+  console.log('Done.');
+}

--- a/.agents/skills/screenshot-embeds/scripts/screenshot.mjs
+++ b/.agents/skills/screenshot-embeds/scripts/screenshot.mjs
@@ -59,8 +59,7 @@ function discoverEmbeds() {
     .filter((name) => {
       const dir = resolve(EMBEDS_DIR, name);
       return (
-        statSync(dir).isDirectory() &&
-        existsSync(resolve(dir, '+page.svelte'))
+        statSync(dir).isDirectory() && existsSync(resolve(dir, '+page.svelte'))
       );
     })
     .map((name) => ({
@@ -151,7 +150,9 @@ if (embeds.length === 0) {
   process.exit(0);
 }
 
-console.log(`Found ${embeds.length} embed(s): ${embeds.map((e) => e.name).join(', ')}`);
+console.log(
+  `Found ${embeds.length} embed(s): ${embeds.map((e) => e.name).join(', ')}`
+);
 
 const chromePath = findChrome();
 console.log(`Using Chrome: ${chromePath}`);
@@ -170,7 +171,9 @@ const browser = await puppeteer.launch({
 
 try {
   for (const embed of embeds) {
-    console.log(`  Screenshotting ${embed.name} (${embed.width}x${embed.height}) ...`);
+    console.log(
+      `  Screenshotting ${embed.name} (${embed.width}x${embed.height}) ...`
+    );
     const page = await browser.newPage();
     await page.setViewport({ width: embed.width, height: embed.height });
     await page.goto(`${BASE}${embed.path}`, {

--- a/.changeset/add-screenshot-embeds-skill.md
+++ b/.changeset/add-screenshot-embeds-skill.md
@@ -1,0 +1,5 @@
+---
+"@reuters-graphics/graphics-components": patch
+---
+
+Add screenshot-embeds agent skill


### PR DESCRIPTION
## Summary

- Adds a screenshot-embeds skill using the open [Agent Skills standard](https://agentskills.io/specification) (SKILL.md), compatible with Claude Code, GitHub Copilot, OpenAI Codex, Gemini CLI, and other agents
- The skill auto-discovers embed pages under `pages/embeds/en/`, starts a Vite dev server, captures each embed with Puppeteer, and saves images to `src/statics/images/embed-{name}.png`
- Self-provisions `puppeteer-core` to `/tmp` at runtime so it doesn't add any project dependencies
- Supports custom per-embed viewport sizes via a `--viewports` CLI flag

## Test plan

- [ ] Run `node .agents/skills/screenshot-embeds/scripts/screenshot.mjs` from a graphics-kit project root with embed pages
- [ ] Verify screenshots appear in `src/statics/images/embed-*.png`
- [ ] Invoke `/screenshot-embeds` from Claude Code and confirm the skill triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)