### PR TITLE
feat(ReferralBlock): manual stories + reusable Referral component

### DIFF
--- a/.changeset/referral-block-manual-stories.md
+++ b/.changeset/referral-block-manual-stories.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Add a `stories` prop to `ReferralBlock` so you can supply your own hand-picked referrals instead of fetching recent stories from Reuters.com. Extract the single-card markup into a new exported `Referral` component for reuse in other layouts, and export `ReferralItem` and `LinkTarget` types.

--- a/src/components/ReferralBlock/Referral.stories.svelte
+++ b/src/components/ReferralBlock/Referral.stories.svelte
@@ -1,0 +1,44 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import Referral from './Referral.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Components/Page furniture/Referral',
+    component: Referral,
+    argTypes: {
+      linkTarget: {
+        control: 'select',
+        options: ['_self', '_blank', '_parent'],
+      },
+      compact: { control: 'boolean' },
+      stacked: { control: 'boolean' },
+    },
+  });
+</script>
+
+<Story
+  name="Demo"
+  args={{
+    url: 'https://www.reuters.com/world/europe/',
+    kicker: 'Europe',
+    title: 'A single referral card you can drop into any layout',
+    imageUrl: 'https://placehold.co/240x240',
+    imageAlt: 'Placeholder image',
+    time: new Date(),
+    stacked: true,
+  }}
+/>
+
+<Story
+  name="No time"
+  exportName="NoTime"
+  args={{
+    url: 'https://www.reuters.com/business/energy/',
+    kicker: 'Energy',
+    title: 'A referral with no publish time shown',
+    imageUrl: 'https://placehold.co/240x240',
+    imageAlt: 'Placeholder image',
+    compact: true,
+    stacked: true,
+  }}
+/>

--- a/src/components/ReferralBlock/Referral.svelte
+++ b/src/components/ReferralBlock/Referral.svelte
@@ -1,0 +1,144 @@
+<!-- @component `Referral` renders a single referral card (a linked headline, kicker, time and thumbnail). It's used by `ReferralBlock` but can be dropped into any layout on its own. -->
+<script lang="ts">
+  // Utils
+  import { getTime } from '../SiteHeader/NavBar/NavDropdown/StoryCard/time';
+
+  // Types
+  import type { ReferralItem, LinkTarget } from './types';
+
+  interface Props extends ReferralItem {
+    /**
+     * Link [target](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target), e.g., `_blank` or `_parent`.
+     */
+    linkTarget?: LinkTarget;
+    /** Use the narrower thumbnail sizing, for tight layouts. */
+    compact?: boolean;
+    /** Render as a single full-width column instead of a half-width card. */
+    stacked?: boolean;
+    /** Add a class to the card's root element. */
+    class?: string;
+  }
+
+  let {
+    url,
+    kicker,
+    title,
+    imageUrl,
+    imageAlt = '',
+    time,
+    linkTarget = '_self',
+    compact = false,
+    stacked = false,
+    class: cls = '',
+  }: Props = $props();
+</script>
+
+<div class="referral {cls}" class:stacked>
+  <a
+    href={url}
+    target={linkTarget}
+    rel={linkTarget === '_blank' ? 'noreferrer' : null}
+  >
+    <div class="referral-pack flex justify-around my-0 mx-auto">
+      <div class="headline" class:xs={compact}>
+        <div
+          class="kicker m-0 body-caption leading-tighter"
+          data-chromatic="ignore"
+        >
+          {kicker}
+        </div>
+        <div
+          class="title m-0 body-caption leading-tighter"
+          data-chromatic="ignore"
+        >
+          {title}
+        </div>
+        {#if time}
+          <div
+            class="publish-time body-caption leading-tighter"
+            data-chromatic="ignore"
+          >
+            {getTime(new Date(time))}
+          </div>
+        {/if}
+      </div>
+      <div
+        class="image-container block m-0 overflow-hidden relative"
+        class:xs={compact}
+      >
+        <img
+          class="block object-cover m-0 w-full"
+          data-chromatic="ignore"
+          src={imageUrl}
+          alt={imageAlt}
+        />
+      </div>
+    </div>
+  </a>
+</div>
+
+<style lang="scss">
+  @use '../../scss/mixins' as mixins;
+
+  a {
+    text-decoration: none;
+  }
+
+  .referral {
+    display: block;
+    width: calc(50% - 30px);
+    max-width: 450px;
+    @include mixins.fmy-1;
+
+    &.stacked {
+      width: 100%;
+      .headline {
+        width: calc(100% - 7rem);
+      }
+    }
+
+    &:hover {
+      .title {
+        text-decoration: underline;
+      }
+      img {
+        filter: brightness(85%);
+      }
+    }
+
+    .headline {
+      display: inline-block;
+      width: calc(100% - 9rem);
+      @include mixins.fpr-2;
+      .kicker {
+        @include mixins.text-xxs;
+        font-family: Knowledge, sans-serif;
+      }
+      .title {
+        @include mixins.fmt-1;
+        @include mixins.font-medium;
+        @include mixins.text-sm;
+        @include mixins.text-primary;
+        font-family: Knowledge, sans-serif;
+      }
+      .publish-time {
+        @include mixins.text-xxs;
+        font-family: Knowledge, sans-serif;
+      }
+    }
+    .image-container {
+      border-radius: 0.25rem;
+      border: 1px solid mixins.$theme-colour-brand-rules;
+      width: 9rem;
+      &.xs {
+        width: 7rem;
+      }
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        transition: filter 0.1s;
+      }
+    }
+  }
+</style>

--- a/src/components/ReferralBlock/ReferralBlock.mdx
+++ b/src/components/ReferralBlock/ReferralBlock.mdx
@@ -41,4 +41,43 @@ TK - Check if this is still relevant.
 ```
 
 <Canvas of={ReferralBlockStories.ByCollection} />
+
+## Manual stories
+
+Pass a `stories` array to populate the block with your own one-off referrals
+instead of fetching them over the wire. When `stories` is set, the
+`section`/`collection` fetch is skipped entirely and your stories render as-is —
+which also means they show up in any environment, not just production
+`www.reuters.com`.
+
+Each story matches the `ReferralItem` type. Only `url`, `kicker`, `title` and
+`imageUrl` are required; `imageAlt` and `time` are optional (omit `time` to hide
+the publish time).
+
+```svelte
+<script>
+  import { ReferralBlock } from '@reuters-graphics/graphics-components';
+
+  const stories = [
+    {
+      url: 'https://www.reuters.com/world/europe/',
+      kicker: 'Europe',
+      title: 'A hand-picked story you provide yourself',
+      imageUrl: 'https://www.reuters.com/your-thumbnail.jpg',
+      imageAlt: 'Describe the image',
+      time: new Date('2026-06-16T12:00:00Z'),
+    },
+    {
+      url: 'https://www.reuters.com/business/energy/',
+      kicker: 'Energy',
+      title: 'Another one-off referral with no publish time',
+      imageUrl: 'https://www.reuters.com/another-thumbnail.jpg',
+    },
+  ];
+</script>
+
+<ReferralBlock {stories} heading="Related coverage" class="fmy-0" />
+```
+
+<Canvas of={ReferralBlockStories.ManualStories} />
 ```

--- a/src/components/ReferralBlock/ReferralBlock.stories.svelte
+++ b/src/components/ReferralBlock/ReferralBlock.stories.svelte
@@ -53,15 +53,7 @@
     argTypes: {
       width: {
         control: 'select',
-        options: [
-          'narrower',
-          'narrow',
-          'normal',
-          'wide',
-          'wider',
-          'widest',
-          'fluid',
-        ],
+        options: ['normal', 'wide', 'wider', 'widest', 'fluid'],
       },
       section: {
         control: 'select',

--- a/src/components/ReferralBlock/ReferralBlock.stories.svelte
+++ b/src/components/ReferralBlock/ReferralBlock.stories.svelte
@@ -1,6 +1,51 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import ReferralBlock from './ReferralBlock.svelte';
+  import { referralsApi } from './getReferrals';
+
+  // A handful of fake Reuters.com articles, shaped like the referral API
+  // response, so the fetch-backed stories render off the network. The
+  // production hostname guard in `getReferrals` is left untouched — we instead
+  // flip the overridable `referralsApi.enabled` seam just for these stories.
+  const MOCK_ARTICLES = [
+    ['World', 'Leaders gather for a summit on shared climate goals'],
+    ['Business', 'Markets edge higher as earnings season gets underway'],
+    ['Sports', 'Underdogs stun the favorites deep into extra time'],
+    ['Technology', 'Chipmakers race to keep pace with surging AI demand'],
+    ['Politics', 'Lawmakers spar over a sweeping new budget package'],
+    ['Science', 'Astronomers spot a surprisingly bright passing comet'],
+    ['Health', 'Researchers report encouraging results from a trial'],
+    ['Culture', 'A career retrospective celebrates a beloved director'],
+  ].map(([kicker, title], i) => ({
+    canonical_url: `/sample/referral-${i}/`,
+    title,
+    headline_category: kicker,
+    kicker: { name: kicker },
+    display_time: new Date(Date.now() - i * 36e5).toISOString(),
+    thumbnail: {
+      url: 'https://placehold.co/240x240',
+      alt_text: 'Placeholder image',
+    },
+  }));
+
+  // Storybook `beforeEach` hook: stub the network fetch and enable the API for
+  // the duration of a story, restoring both afterwards. Applied only to the
+  // fetch-backed stories; "Manual stories" never reaches the fetch path.
+  const mockReferralsFetch = () => {
+    const originalFetch = window.fetch;
+    const originalEnabled = referralsApi.enabled;
+
+    window.fetch = (async () =>
+      new Response(JSON.stringify({ result: { articles: MOCK_ARTICLES } }), {
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof window.fetch;
+    referralsApi.enabled = () => true;
+
+    return () => {
+      window.fetch = originalFetch;
+      referralsApi.enabled = originalEnabled;
+    };
+  };
 
   const { Story } = defineMeta({
     title: 'Components/Page furniture/ReferralBlock',
@@ -8,7 +53,15 @@
     argTypes: {
       width: {
         control: 'select',
-        options: ['normal', 'wide', 'wider', 'widest', 'fluid'],
+        options: [
+          'narrower',
+          'narrow',
+          'normal',
+          'wide',
+          'wider',
+          'widest',
+          'fluid',
+        ],
       },
       section: {
         control: 'select',
@@ -32,6 +85,7 @@
 
 <Story
   name="Demo"
+  beforeEach={mockReferralsFetch}
   args={{
     section: '/lifestyle/sports/',
     class: 'fmy-0',
@@ -42,10 +96,37 @@
 <Story
   name="By collection"
   exportName="ByCollection"
+  beforeEach={mockReferralsFetch}
   args={{
     collection: 'x-trump',
     number: 6,
     class: 'fmy-8',
     heading: 'The latest Trump coverage',
+  }}
+/>
+
+<Story
+  name="Manual stories"
+  exportName="ManualStories"
+  args={{
+    class: 'fmy-0',
+    heading: 'Related coverage',
+    stories: [
+      {
+        url: 'https://www.reuters.com/world/europe/',
+        kicker: 'Europe',
+        title: 'A hand-picked story you provide yourself',
+        imageUrl: 'https://placehold.co/240x240',
+        imageAlt: 'Placeholder image',
+        time: new Date(),
+      },
+      {
+        url: 'https://www.reuters.com/business/energy/',
+        kicker: 'Energy',
+        title: 'Another one-off referral with no publish time',
+        imageUrl: 'https://placehold.co/240x240',
+        imageAlt: 'Placeholder image',
+      },
+    ],
   }}
 />

--- a/src/components/ReferralBlock/ReferralBlock.svelte
+++ b/src/components/ReferralBlock/ReferralBlock.svelte
@@ -12,6 +12,8 @@
   import type { ContainerWidth } from '../@types/global';
   import type { ReferralItem, LinkTarget } from './types';
 
+  type ReferralBlockWidth = Exclude<ContainerWidth, 'narrower' | 'narrow'>;
+
   interface Props {
     /**
      * Section ID, which is often the URL path to the section page on reuters.com.
@@ -42,9 +44,9 @@
      */
     heading?: string;
     /**
-     * Width of the component within the text well: 'narrower' | 'narrow' | 'normal' | 'wide' | 'wider' | 'widest' | 'fluid'
+     * Width of the component within the text well: 'normal' | 'wide' | 'wider' | 'widest' | 'fluid'
      */
-    width?: ContainerWidth;
+    width?: ReferralBlockWidth;
     /** Add an ID to target with SCSS. */
     id?: string;
     /** Add a class to target with SCSS. */

--- a/src/components/ReferralBlock/ReferralBlock.svelte
+++ b/src/components/ReferralBlock/ReferralBlock.svelte
@@ -2,16 +2,15 @@
 <script lang="ts">
   // Utils
   import { onMount } from 'svelte';
-  import { getTime } from '../SiteHeader/NavBar/NavDropdown/StoryCard/time';
-  import { articleIsNotCurrentPage } from './filterCurrentPage';
+  import { fetchReferrals } from './getReferrals';
 
   // Components
   import Block from '../Block/Block.svelte';
+  import Referral from './Referral.svelte';
 
   // Types
-  import type { Article } from './types';
-  import type { Referrals } from './types';
-  type ContainerWidth = 'normal' | 'wide' | 'wider' | 'widest' | 'fluid';
+  import type { ContainerWidth } from '../@types/global';
+  import type { ReferralItem, LinkTarget } from './types';
 
   interface Props {
     /**
@@ -25,19 +24,25 @@
      */
     collection?: string;
     /**
+     * Provide your own referrals instead of fetching recent stories from
+     * Reuters.com. When set, the `section`/`collection` fetch is skipped and
+     * these stories are rendered as-is.
+     */
+    stories?: ReferralItem[];
+    /**
      * Number of referrals to show.
      */
     number?: number;
     /**
      * Link [target](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target), e.g., `_blank` or `_parent`.
      */
-    linkTarget?: string;
+    linkTarget?: LinkTarget;
     /**
      * Add a heading to the referral block.
      */
     heading?: string;
     /**
-     * Width of the component within the text well: 'normal' | 'wide' | 'wider' | 'widest' | 'fluid'
+     * Width of the component within the text well: 'narrower' | 'narrow' | 'normal' | 'wide' | 'wider' | 'widest' | 'fluid'
      */
     width?: ContainerWidth;
     /** Add an ID to target with SCSS. */
@@ -49,6 +54,7 @@
   let {
     section = '/world/',
     collection,
+    stories = [],
     number = 4,
     linkTarget = '_self',
     heading = '',
@@ -59,51 +65,27 @@
 
   let clientWidth = $state(0);
 
-  const SECTION_API = 'recent-stories-by-sections-v1';
+  let fetchedReferrals: ReferralItem[] = $state([]);
 
-  /** @TODO - Check if collections alias API still exists*/
-  const COLLECTION_API = 'articles-by-collection-alias-or-id-v1';
+  // Manually provided stories take precedence. Otherwise, only show fetched
+  // stories once the API returns the full requested number, which avoids
+  // rendering a partial block.
+  const referrals = $derived<ReferralItem[]>(
+    stories.length ? stories
+    : fetchedReferrals.length === number ? fetchedReferrals
+    : []
+  );
 
-  let referrals: Article[] = $state([]);
-
-  const getReferrals = async () => {
-    if (typeof window === 'undefined') return;
-    // fetch only reliably works on prod sites
-    if (window?.location?.hostname !== 'www.reuters.com') return;
-    const isCollection = Boolean(collection);
-    const API = isCollection ? COLLECTION_API : SECTION_API;
-    try {
-      const response = await fetch(
-        `https://www.reuters.com/pf/api/v3/content/fetch/${API}?` +
-          new URLSearchParams({
-            query: JSON.stringify({
-              section_ids: isCollection ? undefined : section,
-              collection_alias: isCollection ? collection : undefined,
-              size: 20,
-              website: 'reuters',
-            }),
-          })
-      );
-
-      const data = (await response.json()) as Referrals;
-
-      const articles = data.result.articles
-        .filter((a) => a?.headline_category || a?.kicker?.name)
-        .filter((a) => a?.thumbnail?.url)
-        .filter((a) => !a?.content?.third_party)
-        .filter(articleIsNotCurrentPage)
-        .slice(0, number);
-
-      referrals = articles;
-    } catch {
-      console.warn('Unable to fetch referral links.');
-    }
-  };
-
-  onMount(getReferrals);
+  onMount(() => {
+    // Skip the network request entirely when stories are supplied by hand.
+    if (stories.length) return;
+    fetchReferrals({ section, collection, number }).then((items) => {
+      fetchedReferrals = items;
+    });
+  });
 </script>
 
-{#if referrals.length === number}
+{#if referrals.length}
   <Block {width} {id} class="referrals-block {cls}">
     <div
       class="block-container"
@@ -124,51 +106,12 @@
         class:xs={clientWidth && clientWidth < 450}
       >
         {#each referrals as referral}
-          <div class="referral">
-            <a
-              href="https://www.reuters.com{referral.canonical_url}"
-              target={linkTarget}
-              rel={linkTarget === '_blank' ? 'noreferrer' : null}
-            >
-              <div class="referral-pack flex justify-around my-0 mx-auto">
-                <div
-                  class="headline"
-                  class:xs={clientWidth && clientWidth < 450}
-                >
-                  <div
-                    class="kicker m-0 body-caption leading-tighter"
-                    data-chromatic="ignore"
-                  >
-                    {referral.headline_category || referral.kicker.name}
-                  </div>
-                  <div
-                    class="title m-0 body-caption leading-tighter"
-                    data-chromatic="ignore"
-                  >
-                    {referral.title}
-                  </div>
-                  <div
-                    class="publish-time body-caption leading-tighter"
-                    data-chromatic="ignore"
-                  >
-                    {getTime(new Date(referral.display_time))}
-                  </div>
-                </div>
-                <div
-                  class="image-container block m-0 overflow-hidden relative"
-                  class:xs={clientWidth && clientWidth < 450}
-                >
-                  <img
-                    class="block object-cover m-0 w-full"
-                    data-chromatic="ignore"
-                    src={referral.thumbnail.url}
-                    alt={referral.thumbnail.alt_text ||
-                      referral.thumbnail.caption}
-                  />
-                </div>
-              </div>
-            </a>
-          </div>
+          <Referral
+            {...referral}
+            {linkTarget}
+            compact={clientWidth > 0 && clientWidth < 450}
+            stacked={clientWidth > 0 && clientWidth < 750}
+          />
         {/each}
       </div>
     </div>
@@ -176,8 +119,6 @@
 {/if}
 
 <style lang="scss">
-  @use '../../scss/mixins' as mixins;
-
   div.block-container.stacked {
     display: flex;
     flex-direction: column;
@@ -193,66 +134,8 @@
   }
 
   .referral-container {
-    a {
-      text-decoration: none;
-    }
     &.stacked {
       max-width: 450px;
-      .referral {
-        width: 100%;
-        .headline {
-          width: calc(100% - 7rem);
-        }
-      }
-    }
-    .referral {
-      display: block;
-      width: calc(50% - 30px);
-      max-width: 450px;
-      @include mixins.fmy-1;
-
-      &:hover {
-        .title {
-          text-decoration: underline;
-        }
-        img {
-          filter: brightness(85%);
-        }
-      }
-
-      .headline {
-        display: inline-block;
-        width: calc(100% - 9rem);
-        @include mixins.fpr-2;
-        .kicker {
-          @include mixins.text-xxs;
-          font-family: Knowledge, sans-serif;
-        }
-        .title {
-          @include mixins.font-medium;
-          @include mixins.text-sm;
-          @include mixins.text-primary;
-          font-family: Knowledge, sans-serif;
-        }
-        .publish-time {
-          @include mixins.text-xxs;
-          font-family: Knowledge, sans-serif;
-        }
-      }
-      .image-container {
-        border-radius: 0.25rem;
-        border: 1px solid mixins.$theme-colour-brand-rules;
-        width: 9rem;
-        &.xs {
-          width: 7rem;
-        }
-        img {
-          width: 100%;
-          height: 100%;
-          object-fit: cover;
-          transition: filter 0.1s;
-        }
-      }
     }
   }
 </style>

--- a/src/components/ReferralBlock/getReferrals.ts
+++ b/src/components/ReferralBlock/getReferrals.ts
@@ -1,0 +1,82 @@
+import { articleIsNotCurrentPage } from './filterCurrentPage';
+import type { Article, Referrals, ReferralItem } from './types';
+
+const SECTION_API = 'recent-stories-by-sections-v1';
+
+/** @TODO - Check if collections alias API still exists*/
+const COLLECTION_API = 'articles-by-collection-alias-or-id-v1';
+
+/** Map a fetched Reuters.com article into the referral shape. */
+const articleToItem = (a: Article): ReferralItem => ({
+  url: `https://www.reuters.com${a.canonical_url}`,
+  kicker: a.headline_category || a.kicker.name,
+  title: a.title,
+  imageUrl: a.thumbnail.url,
+  imageAlt: a.thumbnail.alt_text || a.thumbnail.caption || '',
+  time: new Date(a.display_time),
+});
+
+/**
+ * Environment gate for the live fetch. The Reuters.com referral API is only
+ * same-origin — and therefore CORS-accessible — on production, so by default we
+ * only fetch when running on www.reuters.com. Stories and tests can override
+ * `enabled` to feed mocked data through the real fetch/transform path without
+ * loosening this guard for real, non-production environments.
+ */
+export const referralsApi = {
+  enabled: () =>
+    typeof window !== 'undefined' &&
+    window.location?.hostname === 'www.reuters.com',
+};
+
+interface FetchReferralsOptions {
+  /** Section ID/path passed to the recent-stories-by-section API. */
+  section?: string;
+  /** Collection alias passed to the articles-by-collection API. */
+  collection?: string;
+  /** Maximum number of referrals to return. */
+  number?: number;
+}
+
+/**
+ * Fetch recent Reuters.com stories for a section or collection and map them
+ * into referral items. Returns an empty array when fetching is disabled (see
+ * `referralsApi`) or the request fails.
+ */
+export const fetchReferrals = async ({
+  section = '/world/',
+  collection,
+  number = 4,
+}: FetchReferralsOptions): Promise<ReferralItem[]> => {
+  if (!referralsApi.enabled()) return [];
+
+  const isCollection = Boolean(collection);
+  const API = isCollection ? COLLECTION_API : SECTION_API;
+
+  try {
+    const response = await fetch(
+      `https://www.reuters.com/pf/api/v3/content/fetch/${API}?` +
+        new URLSearchParams({
+          query: JSON.stringify({
+            section_ids: isCollection ? undefined : section,
+            collection_alias: isCollection ? collection : undefined,
+            size: 20,
+            website: 'reuters',
+          }),
+        })
+    );
+
+    const data = (await response.json()) as Referrals;
+
+    return data.result.articles
+      .filter((a) => a?.headline_category || a?.kicker?.name)
+      .filter((a) => a?.thumbnail?.url)
+      .filter((a) => !a?.content?.third_party)
+      .filter(articleIsNotCurrentPage)
+      .slice(0, number)
+      .map(articleToItem);
+  } catch {
+    console.warn('Unable to fetch referral links.');
+    return [];
+  }
+};

--- a/src/components/ReferralBlock/types.ts
+++ b/src/components/ReferralBlock/types.ts
@@ -1,3 +1,37 @@
+/**
+ * A manually authored referral, used to populate `ReferralBlock` with your own
+ * stories instead of fetching recent stories from Reuters.com.
+ */
+export interface ReferralItem {
+  /** URL the referral links to. Used as-is, so include the full address. */
+  url: string;
+  /** Kicker or category text shown above the title. */
+  kicker: string;
+  /** Headline text for the referral. */
+  title: string;
+  /** URL of the thumbnail image. */
+  imageUrl: string;
+  /** Alt text for the thumbnail image. */
+  imageAlt?: string;
+  /**
+   * Publish time shown beneath the title. Accepts a `Date` or any value the
+   * `Date` constructor understands (e.g. an ISO string). Omit to hide the time.
+   */
+  time?: Date | string | number;
+}
+
+/**
+ * Anchor [target](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target)
+ * for a referral link. The standard keywords are suggested, but any named
+ * browsing context is allowed.
+ */
+export type LinkTarget =
+  | '_self'
+  | '_blank'
+  | '_parent'
+  | '_top'
+  | (string & {});
+
 export interface Referrals {
   statusCode: number;
   message: string;
@@ -32,7 +66,7 @@ export interface Article {
   authors: Author[];
   kicker: Kicker;
   content_elements: unknown[];
-  headline_category?: unknown;
+  headline_category?: string;
   content?: {
     third_party?: unknown;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export { default as PhotoPack } from './components/PhotoPack/PhotoPack.svelte';
 export { default as PymChild } from './components/PymChild/PymChild.svelte';
 export { pym } from './components/PymChild/state.svelte';
 export { default as ReferralBlock } from './components/ReferralBlock/ReferralBlock.svelte';
+export { default as Referral } from './components/ReferralBlock/Referral.svelte';
 export { default as ReutersGraphicsLogo } from './components/ReutersGraphicsLogo/ReutersGraphicsLogo.svelte';
 export { default as ReutersLogo } from './components/ReutersLogo/ReutersLogo.svelte';
 export { default as Scroller } from './components/Scroller/Scroller.svelte';
@@ -72,6 +73,9 @@ export type {
   HeadlineSize,
   ScrollerVideoInstance,
 } from './components/@types/global';
+
+export type { ReferralItem } from './components/ReferralBlock/types';
+export type { LinkTarget } from './components/ReferralBlock/types';
 
 export type {
   GeocodeOptions,


### PR DESCRIPTION
## Summary

Enhances `ReferralBlock` so editors can hand-pick referrals instead of only fetching recent stories from Reuters.com, and extracts the single-card markup into a standalone, reusable `Referral` component.

## Changes

- **New `stories` prop on `ReferralBlock`** — pass an array of `ReferralItem`s to render your own one-off referrals. When set, the `section`/`collection` network fetch is skipped entirely.
- **New exported `Referral` component** — the single referral card (linked headline, kicker, optional publish time, thumbnail) is now its own component that can be dropped into any layout. `ReferralBlock` composes it.
- **Tighter types** — adds and exports `ReferralItem` (author-facing input shape) and `LinkTarget` (anchor `target` union with autocomplete). `ReferralBlock` now uses the shared `ContainerWidth` type and the `headline_category` cast was removed.
- **Fetch extracted to `getReferrals.ts`** — the fetch/filter/map logic moved out of the component behind a small `referralsApi.enabled()` seam. The production guard (only fetch on `www.reuters.com`) is unchanged; the seam lets Storybook feed mocked data through the real path.
- **Storybook** — `Demo` and `By collection` stories now mock the fetch (via a `beforeEach` that stubs `window.fetch` and flips the `enabled` seam), so they render off the network on localhost. Adds a `Manual stories` story, a `Referral` story, and updates the MDX docs.
- **Spacing fix** — standardized the kicker→title gap to match the title→time gap.
- Adds a `minor` changeset.

## Testing

- `pnpm check` — 0 errors / 0 warnings
- `pnpm test` — 16 passed
- ESLint + Prettier clean
- knip clean