### PR TITLE
feat(InfoTooltip): add accessible info tooltip component

### DIFF
--- a/.changeset/info-tooltip.md
+++ b/.changeset/info-tooltip.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Add `InfoTooltip`, a small accessible info icon that reveals a tooltip on hover or keyboard focus. Use it to attach a brief explanation to a label, heading, or legend. Supports `text` or custom children content, an `above` position, and a configurable width.

--- a/src/components/InfoTooltip/InfoTooltip.mdx
+++ b/src/components/InfoTooltip/InfoTooltip.mdx
@@ -1,0 +1,48 @@
+import { Meta, Canvas } from '@storybook/blocks';
+
+import * as InfoTooltipStories from './InfoTooltip.stories.svelte';
+
+<Meta of={InfoTooltipStories} />
+
+# InfoTooltip
+
+The `InfoTooltip` component shows a small info icon that reveals a tooltip on
+hover or keyboard focus. Use it to attach a brief explanation to a label,
+heading, chart axis, or legend without cluttering the layout.
+
+```svelte
+<script>
+  import { InfoTooltip } from '@reuters-graphics/graphics-components';
+</script>
+
+<span style="display: inline-flex; align-items: center; gap: 6px;">
+  Difference from normal high
+  <InfoTooltip text="Difference from the 1961–1990 average high temperature." />
+</span>
+```
+
+<Canvas of={InfoTooltipStories.InALabel} />
+
+## Positioning
+
+By default the tooltip opens below the icon. Set `above` to open it above
+instead — handy when the icon sits near the bottom of a container.
+
+<Canvas of={InfoTooltipStories.Above} />
+
+## Custom content
+
+For richer tooltips, pass content as children instead of the `text` prop. The
+children take precedence over `text`.
+
+```svelte
+<InfoTooltip>
+  Read more in our <a href="/methodology/">methodology</a>.
+</InfoTooltip>
+```
+
+## Accessibility
+
+The icon is a real `<button>` so it's reachable by keyboard, and its
+`aria-describedby` is wired to the tooltip, which carries `role="tooltip"`. The
+tooltip reveals on both `:hover` and `:focus-visible`.

--- a/src/components/InfoTooltip/InfoTooltip.stories.svelte
+++ b/src/components/InfoTooltip/InfoTooltip.stories.svelte
@@ -1,0 +1,46 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import InfoTooltip from './InfoTooltip.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Components/Utilities/InfoTooltip',
+    component: InfoTooltip,
+    argTypes: {
+      text: { control: 'text' },
+      above: { control: 'boolean' },
+      width: { control: { type: 'range', min: 120, max: 400, step: 10 } },
+      label: { control: 'text' },
+    },
+    parameters: {
+      layout: 'centered',
+    },
+  });
+</script>
+
+{#snippet inLabel()}
+  <span
+    style="display: inline-flex; align-items: center; gap: 6px; font-weight: bold;"
+  >
+    Difference from normal high
+    <InfoTooltip
+      text="Difference from the 1961–1990 average high temperature."
+    />
+  </span>
+{/snippet}
+
+<Story
+  name="Demo"
+  args={{
+    text: 'Based on UTC calendar days. Forecasts using local times will vary.',
+  }}
+/>
+
+<Story
+  name="Above"
+  args={{
+    above: true,
+    text: 'This tooltip opens above the icon instead of below it.',
+  }}
+/>
+
+<Story name="In a label" exportName="InALabel" children={inLabel} />

--- a/src/components/InfoTooltip/InfoTooltip.svelte
+++ b/src/components/InfoTooltip/InfoTooltip.svelte
@@ -1,0 +1,150 @@
+<!-- @component `InfoTooltip` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-utilities-infotooltip--docs) -->
+<script module lang="ts">
+  // Module-scoped counter gives each instance a unique id so the button's
+  // `aria-describedby` reliably points at its own tooltip, even with many on a
+  // page.
+  let uid = 0;
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    /**
+     * Tooltip text shown on hover or focus. Ignored when a `children` snippet
+     * is provided.
+     */
+    text?: string;
+    /**
+     * Custom tooltip content. Takes precedence over `text` when both are set.
+     */
+    children?: Snippet;
+    /**
+     * Position the tooltip above the icon instead of below it.
+     */
+    above?: boolean;
+    /**
+     * Width of the tooltip, in pixels.
+     */
+    width?: number;
+    /**
+     * Accessible label for the info button, read by screen readers.
+     */
+    label?: string;
+    /** Add a class to the wrapper to target with custom CSS. */
+    class?: string;
+  }
+
+  let {
+    text = '',
+    children,
+    above = false,
+    width = 240,
+    label = 'More information',
+    class: cls = '',
+  }: Props = $props();
+
+  const tooltipId = `info-tooltip-${(uid += 1)}`;
+</script>
+
+<span class="info-tooltip-wrapper {cls}">
+  <button
+    class="info-tooltip-icon"
+    type="button"
+    aria-label={label}
+    aria-describedby={tooltipId}
+  >
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5" />
+      <circle cx="8" cy="5" r="1" fill="currentColor" />
+      <line
+        x1="8"
+        y1="7.5"
+        x2="8"
+        y2="12"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+      />
+    </svg>
+  </button>
+  <span
+    id={tooltipId}
+    class="info-tooltip"
+    class:above
+    style:width="{width}px"
+    role="tooltip"
+  >
+    {#if children}{@render children()}{:else}{text}{/if}
+  </span>
+</span>
+
+<style lang="scss">
+  @use '../../scss/mixins' as mixins;
+
+  .info-tooltip-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .info-tooltip-icon {
+    display: flex;
+    align-items: center;
+    padding: 0;
+    background: none;
+    border: none;
+    font: inherit;
+    color: var(--theme-colour-text-secondary);
+    cursor: help;
+  }
+
+  .info-tooltip {
+    display: none;
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
+    padding: 6px 10px;
+    background: var(--theme-colour-background);
+    border: 1px solid var(--theme-colour-brand-rules);
+    border-radius: 4px;
+    box-shadow: 0 1px 4px rgb(0 0 0 / 15%);
+    color: var(--theme-colour-text-primary);
+    white-space: normal;
+    line-height: 1.4;
+    @include mixins.body-note;
+    @include mixins.text-xs;
+    @include mixins.font-regular;
+
+    &.above {
+      top: auto;
+      bottom: calc(100% + 6px);
+    }
+  }
+
+  .info-tooltip-icon:hover + .info-tooltip,
+  .info-tooltip-icon:focus-visible + .info-tooltip {
+    display: block;
+  }
+
+  @media (max-width: 767px) {
+    .info-tooltip {
+      right: 0;
+      left: auto;
+      transform: none;
+
+      &.above {
+        right: 0;
+        left: auto;
+      }
+    }
+  }
+</style>

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export { default as HeroHeadline } from './components/HeroHeadline/HeroHeadline.
 export { default as HorizontalScroller } from './components/HorizontalScroller/HorizontalScroller.svelte';
 export { default as EndNotes } from './components/EndNotes/EndNotes.svelte';
 export { default as InfoBox } from './components/InfoBox/InfoBox.svelte';
+export { default as InfoTooltip } from './components/InfoTooltip/InfoTooltip.svelte';
 export { default as InlineAd } from './components/AdSlot/InlineAd.svelte';
 export { default as KinesisLogo } from './components/KinesisLogo/KinesisLogo.svelte';
 export { default as LanguageButton } from './components/LanguageButton/LanguageButton.svelte';


### PR DESCRIPTION
## What

Adds a new standalone `InfoTooltip` component to the library — a small accessible info "i" icon that reveals a tooltip on hover or keyboard focus. Use it to attach a brief explanation to a label, heading, chart axis, or legend without cluttering the layout.

It was extracted from the info tooltip baked into the Reuters Climate Monitor's `MapLegend`, generalized for reuse in future projects and restyled to use the library's theme tokens.

## Features

- **Accessible**: the icon is a real `<button>` (keyboard reachable) wired via `aria-describedby` to a tooltip with `role="tooltip"`; reveals on `:hover` and `:focus-visible`.
- **Flexible content**: pass `text` for a simple string, or a `children` snippet for richer content (links, markup).
- **Positioning**: `above` opens the tooltip above the icon instead of below.
- **Configurable**: `width` (px) and `label` (aria-label) props, plus a `class` passthrough.
- Themed with `--theme-*` tokens so it adapts to the consuming project's theme.

## Usage

\`\`\`svelte
<script>
  import { InfoTooltip } from '@reuters-graphics/graphics-components';
</script>

<span style="display: inline-flex; align-items: center; gap: 6px;">
  Difference from normal high
  <InfoTooltip text="Difference from the 1961–1990 average high temperature." />
</span>
\`\`\`

## Includes

- `InfoTooltip.svelte` component
- Storybook stories (Demo, Above, In a label)
- MDX docs
- Barrel export in `src/index.ts`
- Minor changeset