### PR TITLE
fix(InfoBox): tighten interior inline padding on mobile

### DIFF
--- a/.changeset/infobox-mobile-padding.md
+++ b/.changeset/infobox-mobile-padding.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+Reduce `InfoBox` interior inline padding on mobile. The fluid `fpx-6` padding kept a ~2.25rem minimum that squeezed the text in narrow viewports; it now tightens to the page gutter (1rem) below 768px.

--- a/src/components/InfoBox/InfoBox.svelte
+++ b/src/components/InfoBox/InfoBox.svelte
@@ -108,6 +108,15 @@
       border-color: var(--theme-colour-brand-rules);
     }
 
+    // The fluid inline padding (`fpx-6`) keeps a ~2.25rem minimum, which
+    // squeezes the text on narrow screens. Tighten it to match the page
+    // gutter on mobile.
+    @media (max-width: 767px) {
+      :global(.article-block) {
+        padding-inline: 1rem;
+      }
+    }
+
     &.light {
       :global(.article-block) {
         background-color: rgb(250 250 250 / 100%);


### PR DESCRIPTION
## What

Reduces the `InfoBox` interior **inline** padding on narrow viewports.

The box's inner padding comes from the fluid `fpx-6` utility, whose clamp keeps a minimum of ~2.25rem (~36px) even at the smallest screen sizes. On a ~320px box that eats a large share of the width and visibly squeezes the body text (see Storybook's *Small mobile* viewport).

This change tightens the inline padding to the page gutter (`1rem`) below 768px, so the text gets room to breathe on mobile. Vertical padding and all desktop sizing are unchanged.

## Why

This tweak was developed and shipped in the Reuters Climate Monitor frontend (a local `.infobox > div` padding override) and is worth folding back into the base component so every project benefits without a per-project patch.

## Scope

- Inline padding only, and only at `max-width: 767px`.
- Scoped to `InfoBox` — no change to the shared `fpx-*` tokens or other components.

## Includes

- `InfoBox.svelte` mobile padding rule
- Patch changeset

## Before

<img width="1920" height="1005" alt="Screenshot From 2026-06-16 15-36-47" src="https://github.com/user-attachments/assets/fa8c5dbc-a6a6-4a07-9732-71c9f3996618" />

## After

<img width="1920" height="1005" alt="Screenshot From 2026-06-16 15-41-34" src="https://github.com/user-attachments/assets/45536759-f503-4cd9-8334-3e82e28c64f4" />
