### PR TITLE
feat(BioBox): add author bio box component

### DIFF
--- a/.changeset/bio-box.md
+++ b/.changeset/bio-box.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Add `BioBox`, an accessible author-bio box that echoes the contributor box at the bottom of Reuters.com stories. Each author can show a name, job title, short bio, avatar (falling back to the Reuters Kinesis logo) and a row of contact/social links. Social links reflow below the bio text on narrow screens. Also exports the supporting `Bio` and `SocialLinks` components and the `Author`, `SocialLink` and `SocialPlatform` types.

--- a/src/components/BioBox/Bio.svelte
+++ b/src/components/BioBox/Bio.svelte
@@ -1,0 +1,132 @@
+<!-- @component `Bio` renders a single author's avatar, name, title, social links and biography. Used by `BioBox`, but works on its own. -->
+<script lang="ts">
+  import KinesisLogo from '../KinesisLogo/KinesisLogo.svelte';
+  import SocialLinks from './SocialLinks.svelte';
+  import type { Author } from './types';
+
+  interface Props extends Author {
+    /** Extra class on the root element. */
+    class?: string;
+  }
+
+  let {
+    name,
+    title,
+    bio,
+    imageUrl,
+    imageAlt,
+    links = [],
+    class: cls = '',
+  }: Props = $props();
+</script>
+
+<div class="bio {cls}">
+  <div class="bio-header">
+    <div class="bio-identity">
+      {#if imageUrl}
+        <img class="bio-avatar" src={imageUrl} alt={imageAlt ?? name} />
+      {:else}
+        <div class="bio-avatar bio-avatar-fallback" aria-hidden="true">
+          <KinesisLogo width="60%" />
+        </div>
+      {/if}
+      <div class="bio-names">
+        <p class="bio-name">{name}</p>
+        {#if title}<p class="bio-title">{title}</p>{/if}
+      </div>
+    </div>
+    {#if links.length}
+      <div class="bio-links bio-links-inline">
+        <SocialLinks {links} {name} />
+      </div>
+    {/if}
+  </div>
+
+  {#if bio}
+    <p class="bio-text">{bio}</p>
+  {/if}
+
+  {#if links.length}
+    <div class="bio-links bio-links-stacked">
+      <SocialLinks {links} {name} />
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use '../../scss/mixins' as mixins;
+
+  .bio {
+    padding-block: 1rem;
+  }
+
+  .bio-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .bio-identity {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .bio-avatar {
+    display: block;
+    width: 3rem;
+    height: 3rem;
+    margin: 0;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .bio-avatar-fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--theme-colour-background, #fff);
+    border: 1px solid var(--theme-colour-brand-rules, #e5e5e5);
+  }
+
+  .bio-name {
+    @include mixins.font-knowledge;
+    @include mixins.font-bold;
+    @include mixins.text-base;
+    margin: 0;
+    line-height: 1.2;
+    color: var(--theme-colour-text-primary, #121212);
+  }
+
+  .bio-title {
+    @include mixins.font-knowledge;
+    @include mixins.text-sm;
+    margin: 0.1rem 0 0;
+    color: var(--theme-colour-text-secondary, #666);
+  }
+
+  .bio-text {
+    @include mixins.font-knowledge;
+    @include mixins.text-sm;
+    margin: 0.75rem 0 0;
+    line-height: 1.5;
+    color: var(--theme-colour-text-primary, #121212);
+  }
+
+  .bio-links-stacked {
+    display: none;
+  }
+
+  @media (max-width: 520px) {
+    .bio-links-inline {
+      display: none;
+    }
+
+    .bio-links-stacked {
+      display: block;
+      margin-top: 0.75rem;
+    }
+  }
+</style>

--- a/src/components/BioBox/BioBox.mdx
+++ b/src/components/BioBox/BioBox.mdx
@@ -1,0 +1,48 @@
+import { Meta, Canvas } from '@storybook/blocks';
+
+import * as BioBoxStories from './BioBox.stories.svelte';
+
+<Meta of={BioBoxStories} />
+
+# BioBox
+
+The `BioBox` component shows one or more author biographies in a bordered box, echoing the contributor box at the bottom of Reuters.com stories.
+
+Each author can include a name, job title, short bio, avatar image and a row of contact and social links (email, X, LinkedIn, Facebook, Instagram, Bluesky or a generic link). When no avatar is provided, the Reuters Kinesis logo is shown instead.
+
+On narrow screens the social links move below the bio text so names and titles stay readable.
+
+```svelte
+<script>
+  import { BioBox } from '@reuters-graphics/graphics-components';
+
+  const authors = [
+    {
+      name: 'Ben Welsh',
+      title: 'News Applications Editor',
+      bio: 'Ben Welsh leads the development of dashboards, databases and other automated systems.',
+      imageUrl: 'https://www.reuters.com/.../avatar.jpg',
+      links: [
+        { platform: 'email', url: 'ben.welsh@thomsonreuters.com' },
+        { platform: 'x', url: 'https://x.com/palewire' },
+        { platform: 'linkedin', url: 'https://www.linkedin.com/in/palewire' },
+        { platform: 'link', url: 'https://palewi.re/who-is-ben-welsh/' },
+      ],
+    },
+  ];
+</script>
+
+<BioBox {authors} width="normal" />
+```
+
+<Canvas of={BioBoxStories.Demo} />
+
+## Single author
+
+<Canvas of={BioBoxStories.SingleAuthor} />
+
+## Logo fallback
+
+When an author has no `imageUrl`, the box falls back to the Reuters Kinesis logo.
+
+<Canvas of={BioBoxStories.LogoFallback} />

--- a/src/components/BioBox/BioBox.mdx
+++ b/src/components/BioBox/BioBox.mdx
@@ -32,7 +32,7 @@ On narrow screens the social links move below the bio text so names and titles s
   ];
 </script>
 
-<BioBox {authors} width="normal" />
+<BioBox {authors} />
 ```
 
 <Canvas of={BioBoxStories.Demo} />

--- a/src/components/BioBox/BioBox.stories.svelte
+++ b/src/components/BioBox/BioBox.stories.svelte
@@ -1,0 +1,64 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import BioBox from './BioBox.svelte';
+  import type { Author } from './types';
+
+  const authors: Author[] = [
+    {
+      name: 'Ben Welsh',
+      title: 'News Applications Editor',
+      bio: 'Ben Welsh leads the development of dashboards, databases and other automated systems.',
+      imageUrl:
+        'https://www.reuters.com/resizer/v2/https%3A%2F%2Fauthor-service-images-prod-us-east-1.publishing.aws.arc.pub%2Freuters%2F23a41163-d18c-4871-be7a-d6167693bd29.jpg?auth=b4deb5011d667930faf2b6a26a17a7397b5691c2178fc1083462d67dc8996475&height=120&width=120&quality=80&smart=true',
+      links: [
+        { platform: 'email', url: 'ben.welsh@thomsonreuters.com' },
+        { platform: 'x', url: 'https://x.com/palewire' },
+        { platform: 'linkedin', url: 'https://www.linkedin.com/in/palewire' },
+        { platform: 'link', url: 'https://palewi.re/who-is-ben-welsh/' },
+      ],
+    },
+    {
+      name: 'Casey Miller',
+      title: 'News Applications Developer',
+      bio: 'Casey Miller develops maps, dashboards and other automated systems.',
+      imageUrl:
+        'https://www.reuters.com/resizer/v2/https%3A%2F%2Fauthor-service-images-prod-us-east-1.publishing.aws.arc.pub%2Freuters%2F1c168c03-8c8b-4e4a-9458-f65a2749b962.png?auth=3f19fad9ea147f79e280668358df9e9ab011a136cd4a8a013502d5d0a06cf42d&height=120&width=120&quality=80&smart=true',
+      links: [{ platform: 'email', url: 'casey.miller@thomsonreuters.com' }],
+    },
+  ];
+
+  const { Story } = defineMeta({
+    title: 'Components/Page furniture/BioBox',
+    component: BioBox,
+    argTypes: {
+      width: {
+        control: 'select',
+        options: ['normal', 'wide', 'wider', 'widest', 'fluid'],
+      },
+    },
+  });
+</script>
+
+<Story name="Demo" args={{ authors, width: 'normal' }} />
+
+<Story
+  name="Single author"
+  exportName="SingleAuthor"
+  args={{ authors: [authors[1]], width: 'normal' }}
+/>
+
+<Story
+  name="Logo fallback"
+  exportName="LogoFallback"
+  args={{
+    authors: [
+      {
+        name: 'Reuters Graphics',
+        title: 'News Applications Team',
+        bio: 'When no avatar is provided, the Reuters Kinesis logo is shown instead.',
+        links: [{ platform: 'link', url: 'https://www.reuters.com/graphics/' }],
+      },
+    ],
+    width: 'normal',
+  }}
+/>

--- a/src/components/BioBox/BioBox.stories.svelte
+++ b/src/components/BioBox/BioBox.stories.svelte
@@ -30,21 +30,15 @@
   const { Story } = defineMeta({
     title: 'Components/Page furniture/BioBox',
     component: BioBox,
-    argTypes: {
-      width: {
-        control: 'select',
-        options: ['normal', 'wide', 'wider', 'widest', 'fluid'],
-      },
-    },
   });
 </script>
 
-<Story name="Demo" args={{ authors, width: 'normal' }} />
+<Story name="Demo" args={{ authors }} />
 
 <Story
   name="Single author"
   exportName="SingleAuthor"
-  args={{ authors: [authors[1]], width: 'normal' }}
+  args={{ authors: [authors[1]] }}
 />
 
 <Story
@@ -59,6 +53,5 @@
         links: [{ platform: 'link', url: 'https://www.reuters.com/graphics/' }],
       },
     ],
-    width: 'normal',
   }}
 />

--- a/src/components/BioBox/BioBox.svelte
+++ b/src/components/BioBox/BioBox.svelte
@@ -1,0 +1,60 @@
+<!-- @component `BioBox` shows one or more author biographies in a bordered box, echoing the contributor box on Reuters.com stories. [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-page-furniture-biobox--docs) -->
+<script lang="ts">
+  import Block from '../Block/Block.svelte';
+  import type { ContainerWidth } from '../@types/global';
+  import Bio from './Bio.svelte';
+  import type { Author } from './types';
+
+  interface Props {
+    /** Authors to display, in order. */
+    authors: Author[];
+    /** Width of the containing block. */
+    width?: ContainerWidth;
+    /** ID on the containing block. */
+    id?: string;
+    /** Extra classes on the containing block. */
+    class?: string;
+  }
+
+  let {
+    authors,
+    width = 'normal',
+    id = '',
+    class: cls = 'fmy-8',
+  }: Props = $props();
+</script>
+
+{#if authors.length}
+  <Block {width} {id} class="biobox {cls}">
+    <div class="biobox-inner">
+      {#each authors as author, i}
+        <Bio {...author} />
+        {#if i < authors.length - 1}
+          <hr class="biobox-divider" />
+        {/if}
+      {/each}
+    </div>
+  </Block>
+{/if}
+
+<style lang="scss">
+  .biobox-inner {
+    padding: 0.5rem 1.25rem;
+    border: 1px solid var(--theme-colour-brand-rules, #d3d3d3);
+    border-radius: 4px;
+    background: var(--theme-colour-background, #fff);
+  }
+
+  .biobox-divider {
+    border: 0;
+    border-top: 1px solid var(--theme-colour-brand-rules, #d3d3d3);
+    opacity: 0.5;
+    margin: 0.5rem 0;
+  }
+
+  @media (max-width: 767px) {
+    .biobox-inner {
+      padding-inline: 1rem;
+    }
+  }
+</style>

--- a/src/components/BioBox/BioBox.svelte
+++ b/src/components/BioBox/BioBox.svelte
@@ -1,31 +1,23 @@
 <!-- @component `BioBox` shows one or more author biographies in a bordered box, echoing the contributor box on Reuters.com stories. [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-page-furniture-biobox--docs) -->
 <script lang="ts">
   import Block from '../Block/Block.svelte';
-  import type { ContainerWidth } from '../@types/global';
   import Bio from './Bio.svelte';
   import type { Author } from './types';
 
   interface Props {
     /** Authors to display, in order. */
     authors: Author[];
-    /** Width of the containing block. */
-    width?: ContainerWidth;
     /** ID on the containing block. */
     id?: string;
     /** Extra classes on the containing block. */
     class?: string;
   }
 
-  let {
-    authors,
-    width = 'normal',
-    id = '',
-    class: cls = 'fmy-8',
-  }: Props = $props();
+  let { authors, id = '', class: cls = 'fmy-8' }: Props = $props();
 </script>
 
 {#if authors.length}
-  <Block {width} {id} class="biobox {cls}">
+  <Block {id} class="biobox {cls}">
     <div class="biobox-inner">
       {#each authors as author, i}
         <Bio {...author} />

--- a/src/components/BioBox/SocialLinks.svelte
+++ b/src/components/BioBox/SocialLinks.svelte
@@ -1,0 +1,173 @@
+<!-- @component `SocialLinks` renders a row of accessible icon links (email, X, LinkedIn, etc.) for a single author. Used by `Bio`. -->
+<script lang="ts">
+  import type { SocialLink, SocialPlatform } from './types';
+
+  interface Props {
+    /** Links to render. Unknown platforms fall back to a generic link icon. */
+    links: SocialLink[];
+    /** Author name, used to build default accessible labels. */
+    name?: string;
+  }
+
+  let { links, name = '' }: Props = $props();
+
+  // Normalize an email destination into a usable href.
+  function hrefFor(link: SocialLink): string {
+    if (link.platform === 'email' && !/^mailto:/i.test(link.url)) {
+      return `mailto:${link.url}`;
+    }
+    return link.url;
+  }
+
+  // Default, screen-reader-friendly label per platform.
+  const PLATFORM_NOUN: Record<SocialPlatform, string> = {
+    email: 'Email',
+    x: 'X profile of',
+    twitter: 'X profile of',
+    linkedin: 'LinkedIn profile of',
+    facebook: 'Facebook profile of',
+    instagram: 'Instagram profile of',
+    bluesky: 'Bluesky profile of',
+    link: 'Profile of',
+  };
+
+  function labelFor(link: SocialLink): string {
+    if (link.label) return link.label;
+    const noun = PLATFORM_NOUN[link.platform] ?? PLATFORM_NOUN.link;
+    return name ? `${noun} ${name}` : noun;
+  }
+</script>
+
+<div class="social-links">
+  {#each links as link}
+    <a
+      class="social-link"
+      href={hrefFor(link)}
+      aria-label={labelFor(link)}
+      target={link.platform === 'email' ? null : '_blank'}
+      rel={link.platform === 'email' ? null : 'noreferrer'}
+    >
+      {#if link.platform === 'email'}
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <rect
+            x="3"
+            y="5"
+            width="18"
+            height="14"
+            rx="2"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+          />
+          <path
+            d="M4 7l8 6 8-6"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      {:else if link.platform === 'x' || link.platform === 'twitter'}
+        <svg viewBox="0 0 30 30" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M17.923 14.387 25.569 5.5h-1.812l-6.64 7.717L11.817 5.5H5.7l8.018 11.67L5.7 26.49h1.812l7.01-8.15 5.6 8.15h6.116l-8.316-12.102Zm-2.482 2.885-.812-1.162-6.464-9.246h2.783l5.216 7.462.813 1.162 6.78 9.7h-2.782l-5.534-7.915Z"
+          />
+        </svg>
+      {:else if link.platform === 'linkedin'}
+        <svg viewBox="0 0 21 21" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M19.031 0c1.034 0 1.888.807 1.964 1.822L21 1.97V19.03a1.975 1.975 0 0 1-1.822 1.964L19.03 21H1.97a1.975 1.975 0 0 1-1.964-1.822L0 19.03V1.97C0 .935.807.08 1.822.005L1.97 0H19.03ZM6.3 7.875H3.15v10.063H6.3V7.874Zm7.875-.175c-1.575 0-2.538.788-2.975 1.575v-1.4H8.225v10.063h3.15V12.95c0-1.313.175-2.537 1.838-2.537 1.575 0 1.575 1.487 1.575 2.624v4.9h3.15v-5.425c0-2.712-.613-4.812-3.763-4.812ZM4.637 2.8c-1.05 0-1.837.875-1.837 1.838 0 1.05.875 1.837 1.838 1.837 1.05 0 1.837-.787 1.837-1.837 0-1.05-.875-1.838-1.837-1.838Z"
+          />
+        </svg>
+      {:else if link.platform === 'facebook'}
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M13.5 21v-8h2.7l.4-3.1h-3.1V7.9c0-.9.25-1.5 1.55-1.5H17V3.6c-.3 0-1.3-.1-2.45-.1-2.43 0-4.05 1.48-4.05 4.2v2.2H7.8V13h2.7v8h3Z"
+          />
+        </svg>
+      {:else if link.platform === 'instagram'}
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <rect
+            x="3.5"
+            y="3.5"
+            width="17"
+            height="17"
+            rx="5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            r="4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+          />
+          <circle cx="17.2" cy="6.8" r="1.1" fill="currentColor" />
+        </svg>
+      {:else if link.platform === 'bluesky'}
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M12 10.8C10.9 8.6 7.9 4.6 5.2 3.2 2.6 1.9 1.6 2.4 1 2.9.3 3.5 0 4.7 0 5.4c0 .7.4 5.6.6 6.4.7 2.7 3.5 3.6 6.1 3.3-3.8.6-7.2 2-2.8 6.9 4.9 5 6.7-1 7.6-4.1.9 3.1 2 8.9 7.5 4.1 4.1-4.1 1.1-6.3-2.7-6.9 2.6.3 5.4-.6 6.1-3.3.2-.8.6-5.7.6-6.4 0-.7-.3-1.9-1-2.5-.6-.5-1.6-1-4.2.3C16.1 4.6 13.1 8.6 12 10.8Z"
+          />
+        </svg>
+      {:else}
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M10 14a3.5 3.5 0 0 0 5 0l3-3a3.5 3.5 0 0 0-5-5l-1.5 1.5M14 10a3.5 3.5 0 0 0-5 0l-3 3a3.5 3.5 0 0 0 5 5l1.5-1.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      {/if}
+    </a>
+  {/each}
+</div>
+
+<style lang="scss">
+  .social-links {
+    display: inline-flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .social-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid var(--theme-colour-brand-rules, #d3d3d3);
+    border-radius: 4px;
+    color: var(--theme-colour-text-secondary, #666);
+    background: transparent;
+    text-decoration: none;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .social-link:hover,
+  .social-link:focus-visible {
+    color: var(--theme-colour-text-primary, #121212);
+    border-color: var(--theme-colour-text-secondary, #666);
+    background: rgb(0 0 0 / 3%);
+  }
+
+  .social-link svg {
+    width: 1rem;
+    height: 1rem;
+    display: block;
+  }
+</style>

--- a/src/components/BioBox/types.ts
+++ b/src/components/BioBox/types.ts
@@ -1,0 +1,42 @@
+/** Social/contact platforms a bio can link to. */
+export type SocialPlatform =
+  | 'email'
+  | 'x'
+  | 'twitter'
+  | 'linkedin'
+  | 'facebook'
+  | 'instagram'
+  | 'bluesky'
+  | 'link';
+
+/** A single contact or social link shown beside an author's name. */
+export interface SocialLink {
+  /** Which platform this link points to. Controls the icon shown. */
+  platform: SocialPlatform;
+  /**
+   * Destination. For `email`, either a bare address or a `mailto:` URL — the
+   * component adds the `mailto:` prefix if it's missing.
+   */
+  url: string;
+  /**
+   * Accessible label for the link, read by screen readers. Defaults to a
+   * sensible per-platform label that includes the author's name.
+   */
+  label?: string;
+}
+
+/** One author/contributor rendered as a row inside `BioBox`. */
+export interface Author {
+  /** Full name, shown in bold. */
+  name: string;
+  /** Job title, shown under the name, e.g. "Climate reporter". */
+  title?: string;
+  /** Short biography. Plain text. */
+  bio?: string;
+  /** Avatar image URL. Falls back to the Reuters Kinesis logo when omitted. */
+  imageUrl?: string;
+  /** Alt text for the avatar image. Defaults to the author's name. */
+  imageAlt?: string;
+  /** Contact and social links shown beside the name. */
+  links?: SocialLink[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@ export { default as BlogPost } from './components/BlogPost/BlogPost.svelte';
 export { default as BlogTOC } from './components/BlogTOC/BlogTOC.svelte';
 export { default as AdScripts } from './components/AdSlot/AdScripts.svelte';
 export { default as BeforeAfter } from './components/BeforeAfter/BeforeAfter.svelte';
+export { default as Bio } from './components/BioBox/Bio.svelte';
+export { default as BioBox } from './components/BioBox/BioBox.svelte';
+export { default as SocialLinks } from './components/BioBox/SocialLinks.svelte';
 export { default as Block } from './components/Block/Block.svelte';
 export { default as ClockWall } from './components/ClockWall/ClockWall.svelte';
 export { default as BodyText } from './components/BodyText/BodyText.svelte';
@@ -72,6 +75,12 @@ export type {
   HeadlineSize,
   ScrollerVideoInstance,
 } from './components/@types/global';
+
+export type {
+  Author,
+  SocialLink,
+  SocialPlatform,
+} from './components/BioBox/types';
 
 export type {
   GeocodeOptions,


### PR DESCRIPTION
## What

Adds `BioBox`, an accessible author-bio box that echoes the contributor box at the bottom of Reuters.com stories.

Each author can include:
- Name and job title
- A short bio
- An avatar image, falling back to the Reuters Kinesis logo when none is provided
- A row of contact/social links (email, X, LinkedIn, Facebook, Instagram, Bluesky or a generic link)

On narrow screens the social links reflow below the bio text so names and titles stay readable. All copy uses the Knowledge font.

<img width="824" height="487" alt="Screenshot From 2026-06-16 16-27-00" src="https://github.com/user-attachments/assets/0ffebade-0a0d-48ef-ac7f-539ea9bef624" />


## Exports

- `BioBox` (and the supporting `Bio` and `SocialLinks` components)
- `Author`, `SocialLink` and `SocialPlatform` types

## Notes

- Storybook stories and MDX docs included (Components → Page furniture → BioBox), covering multiple authors, a single author and the logo-fallback variant.
- Changeset added (minor bump).
- `pnpm check` passes with 0 errors / 0 warnings; prettier and eslint clean.