### PR TITLE
feat(TileMap): label-legibility controls for data overlays (beneathLabels + emphasizeLabels)

### DIFF
--- a/.changeset/tilemap-label-controls.md
+++ b/.changeset/tilemap-label-controls.md
@@ -1,0 +1,13 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+**TileMap:** add label-legibility controls for data overlays.
+
+- `TileMapLayer` gains a `beneathLabels` boolean that inserts the layer just
+  below the basemap's first symbol (label) layer, so place names stay readable
+  on top of a colored fill — without needing to know the style's label-layer id
+  (an explicit `beforeId` still takes precedence).
+- `TileMap` gains an `emphasizeLabels` boolean that darkens the basemap's
+  `place` labels and adds a strong white halo on map load. Both degrade
+  gracefully (no-ops) on styles without the expected symbol layers.

--- a/src/components/TileMap/TileMap.mdx
+++ b/src/components/TileMap/TileMap.mdx
@@ -193,6 +193,7 @@ You can also pass a URL string to fetch GeoJSON data:
 - **paint**: `Record<string, unknown>` - Paint properties for the layer
 - **layout**: `Record<string, unknown>` - Layout properties for the layer
 - **beforeId**: `string` - Layer ID to insert before (for ordering)
+- **beneathLabels**: `boolean` - Insert the layer beneath the basemap's labels so place names stay readable on top of it (default: `false`). Ignored when `beforeId` is set. A no-op on styles with no symbol layers.
 - **minZoom**: `number` - Minimum zoom level to display layer
 - **maxZoom**: `number` - Maximum zoom level to display layer
 - **filter**: `unknown[]` - Filter expression for the layer
@@ -281,6 +282,7 @@ For more control over the map, you can use the `onMapReady` callback to access t
 - **maxZoom**: `number` - Maximum zoom level (default: `22`)
 - **interactive**: `boolean` - Enable interactive controls (default: `true`)
 - **styleUrl**: `string` - Map style URL (default: Reuters Protomaps style)
+- **emphasizeLabels**: `boolean` - Darken the basemap's place labels and add a white halo so city/region names stay readable over colored data layers (default: `false`). Applied on map load; a no-op on styles without `place` labels.
 - **height**: `string` - Map height in CSS units (default: `'500px'`)
 - **width**: `ContainerWidth` - Width within the text well (default: `'normal'`)
 - **onMapReady**: `(map: maplibregl.Map) => void` - Callback when map is ready

--- a/src/components/TileMap/TileMap.stories.svelte
+++ b/src/components/TileMap/TileMap.stories.svelte
@@ -296,7 +296,7 @@
       beneathLabels
       paint={{
         'fill-color': '#d64000',
-        'fill-opacity': 0.6,
+        'fill-opacity': 0.75,
       }}
     />
   </TileMap>

--- a/src/components/TileMap/TileMap.stories.svelte
+++ b/src/components/TileMap/TileMap.stories.svelte
@@ -29,6 +29,74 @@
     ],
   };
 
+  // Simplified outline of the state of Iowa, for the "labels above data" demo.
+  const iowaData: FeatureCollection<Polygon> = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-91.3684, 43.5014],
+              [-91.2151, 43.5014],
+              [-91.2041, 43.3535],
+              [-91.0562, 43.2549],
+              [-91.1767, 43.1344],
+              [-91.1439, 42.9099],
+              [-91.0672, 42.7511],
+              [-90.7112, 42.636],
+              [-90.64, 42.5101],
+              [-90.4209, 42.3293],
+              [-90.3935, 42.2253],
+              [-90.169, 42.1267],
+              [-90.1416, 42.0007],
+              [-90.1799, 41.809],
+              [-90.3114, 41.7433],
+              [-90.3442, 41.5899],
+              [-90.6564, 41.464],
+              [-91.0453, 41.4147],
+              [-91.111, 41.2394],
+              [-90.9467, 41.097],
+              [-90.9631, 40.9218],
+              [-91.0946, 40.8232],
+              [-91.122, 40.6698],
+              [-91.4013, 40.5603],
+              [-91.4177, 40.3795],
+              [-91.5272, 40.4124],
+              [-91.7299, 40.615],
+              [-91.834, 40.6096],
+              [-93.258, 40.5822],
+              [-94.6327, 40.5712],
+              [-95.7664, 40.5877],
+              [-95.8814, 40.7191],
+              [-95.8266, 40.9765],
+              [-95.9252, 41.2011],
+              [-95.9198, 41.453],
+              [-96.095, 41.5406],
+              [-96.1224, 41.6776],
+              [-96.0622, 41.7981],
+              [-96.1279, 41.9733],
+              [-96.2648, 42.039],
+              [-96.4455, 42.4882],
+              [-96.6318, 42.7072],
+              [-96.5441, 42.8551],
+              [-96.5113, 43.0523],
+              [-96.4346, 43.1235],
+              [-96.5606, 43.2221],
+              [-96.5277, 43.3973],
+              [-96.5825, 43.4795],
+              [-96.451, 43.5014],
+              [-91.3684, 43.5014],
+            ],
+          ],
+        },
+      },
+    ],
+  };
+
   // Reuters office location
   const reutersOfficePoint: FeatureCollection<Point> = {
     type: 'FeatureCollection',
@@ -205,6 +273,30 @@
         'circle-color': '#9c27b0',
         'circle-stroke-width': 2,
         'circle-stroke-color': '#ffffff',
+      }}
+    />
+  </TileMap>
+</Story>
+
+<Story name="Labels above data" tags={['!autodocs']}>
+  <TileMap
+    id="labels-map"
+    center={[-93.5, 42]}
+    zoom={6}
+    interactive={true}
+    emphasizeLabels
+    title="Keeping labels readable over data"
+    description="`emphasizeLabels` (on the map) darkens the basemap's place labels and adds a white halo; `beneathLabels` (on the fill layer) inserts the data below the labels, so city names across Iowa stay on top of the colored overlay."
+    height="500px"
+  >
+    <TileMapLayer
+      id="iowa-fill"
+      data={iowaData}
+      type="fill"
+      beneathLabels
+      paint={{
+        'fill-color': '#d64000',
+        'fill-opacity': 0.6,
       }}
     />
   </TileMap>

--- a/src/components/TileMap/TileMap.svelte
+++ b/src/components/TileMap/TileMap.svelte
@@ -174,8 +174,14 @@
         }
 
         // Darken the basemap's place labels so they read over data layers.
+        // Apply now, then re-assert once the map settles — some styles finish
+        // applying their own label paint just after `load`, which would
+        // otherwise win and leave the labels their default (lighter) color.
         if (emphasizeLabels) {
           emphasizePlaceLabels(map);
+          map.once('idle', () => {
+            if (map) emphasizePlaceLabels(map);
+          });
         }
 
         if (onMapReady) {

--- a/src/components/TileMap/TileMap.svelte
+++ b/src/components/TileMap/TileMap.svelte
@@ -164,6 +164,28 @@
         );
       }
 
+      // Darken the basemap's place labels so they read over data layers. Some
+      // styles keep applying their own label paint for a moment after the style
+      // loads, so a single call at `load` can be overridden and leave the
+      // labels their default (lighter) color. Apply on the first `styledata`
+      // where the place labels are present, then stop listening.
+      if (emphasizeLabels) {
+        const applyLabelEmphasis = () => {
+          if (!map) return;
+          const hasPlaceLabels = map
+            .getStyle()
+            ?.layers?.some(
+              (l) =>
+                l.type === 'symbol' &&
+                (l as { 'source-layer'?: string })['source-layer'] === 'place'
+            );
+          if (!hasPlaceLabels) return;
+          emphasizePlaceLabels(map);
+          map.off('styledata', applyLabelEmphasis);
+        };
+        map.on('styledata', applyLabelEmphasis);
+      }
+
       // Call the callback when map is ready
       map.on('load', () => {
         if (!map) return;
@@ -171,17 +193,6 @@
         // Set projection after map loads if specified
         if (projection) {
           map.setProjection(projection);
-        }
-
-        // Darken the basemap's place labels so they read over data layers.
-        // Apply now, then re-assert once the map settles — some styles finish
-        // applying their own label paint just after `load`, which would
-        // otherwise win and leave the labels their default (lighter) color.
-        if (emphasizeLabels) {
-          emphasizePlaceLabels(map);
-          map.once('idle', () => {
-            if (map) emphasizePlaceLabels(map);
-          });
         }
 
         if (onMapReady) {

--- a/src/components/TileMap/TileMap.svelte
+++ b/src/components/TileMap/TileMap.svelte
@@ -21,6 +21,7 @@
   import GraphicBlock from '../GraphicBlock/GraphicBlock.svelte';
   import type { ContainerWidth } from '../@types/global';
   import type { ProjectionSpecification } from 'maplibre-gl';
+  import { emphasizePlaceLabels } from './labels';
   import 'maplibre-gl/dist/maplibre-gl.css';
 
   interface Props {
@@ -66,6 +67,13 @@
      */
     styleUrl?: string;
     /**
+     * Darken the basemap's place labels and give them a strong white halo, so
+     * city/region names stay readable over colored data layers. Applied once on
+     * map load; a no-op on styles without `place` labels (e.g. non-default
+     * `styleUrl`s), so it degrades gracefully.
+     */
+    emphasizeLabels?: boolean;
+    /**
      * Map height (default: '500px')
      */
     height?: string;
@@ -101,6 +109,7 @@
     projection,
     interactive = true,
     styleUrl = 'https://graphics.thomsonreuters.com/reuters-protomaps/style.json',
+    emphasizeLabels = false,
     height = '500px',
     width = 'normal',
     textWidth = 'normal',
@@ -162,6 +171,11 @@
         // Set projection after map loads if specified
         if (projection) {
           map.setProjection(projection);
+        }
+
+        // Darken the basemap's place labels so they read over data layers.
+        if (emphasizeLabels) {
+          emphasizePlaceLabels(map);
         }
 
         if (onMapReady) {

--- a/src/components/TileMap/TileMapLayer.svelte
+++ b/src/components/TileMap/TileMapLayer.svelte
@@ -4,6 +4,7 @@
   import type { Map as MaplibreMap, GeoJSONSource } from 'maplibre-gl';
   import type { Writable } from 'svelte/store';
   import type { GeoJSON } from 'geojson';
+  import { findFirstSymbolLayerId } from './labels';
 
   interface Props {
     /**
@@ -40,6 +41,12 @@
      */
     beforeId?: string;
     /**
+     * Insert this layer beneath the basemap's labels, so place names and other
+     * symbol layers stay readable on top of it. Ignored when `beforeId` is set
+     * (that takes precedence). A no-op on styles with no symbol layers.
+     */
+    beneathLabels?: boolean;
+    /**
      * Minimum zoom level to display layer
      */
     minZoom?: number;
@@ -60,6 +67,7 @@
     paint = {},
     layout = {},
     beforeId,
+    beneathLabels = false,
     minZoom,
     maxZoom,
     filter,
@@ -146,7 +154,11 @@
         if (maxZoom !== undefined) layerConfig.maxzoom = maxZoom;
         if (filter) layerConfig.filter = filter;
 
-        map.addLayer(layerConfig as never, beforeId);
+        // An explicit `beforeId` wins; otherwise `beneathLabels` inserts the
+        // layer just below the first symbol (label) layer so labels stay on top.
+        const insertBefore =
+          beforeId ?? (beneathLabels ? findFirstSymbolLayerId(map) : undefined);
+        map.addLayer(layerConfig as never, insertBefore);
       }
 
       isInitialized = true;

--- a/src/components/TileMap/labels.test.ts
+++ b/src/components/TileMap/labels.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import type { Map as MaplibreMap } from 'maplibre-gl';
+import { findFirstSymbolLayerId, emphasizePlaceLabels } from './labels';
+
+/** Minimal fake MapLibre map for exercising the pure label helpers. */
+function fakeMap(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  layers: any[] | undefined
+): {
+  map: MaplibreMap;
+  calls: { id: string; prop: string; val: unknown }[];
+} {
+  const calls: { id: string; prop: string; val: unknown }[] = [];
+  const map = {
+    getStyle: () => (layers ? { layers } : undefined),
+    setPaintProperty: (id: string, prop: string, val: unknown) =>
+      calls.push({ id, prop, val }),
+  };
+  return { map: map as unknown as MaplibreMap, calls };
+}
+
+describe('findFirstSymbolLayerId', () => {
+  it('returns the id of the first symbol layer', () => {
+    const { map } = fakeMap([
+      { id: 'background', type: 'background' },
+      { id: 'roads', type: 'line' },
+      { id: 'road_labels', type: 'symbol' },
+      { id: 'place_labels', type: 'symbol' },
+    ]);
+    expect(findFirstSymbolLayerId(map)).toBe('road_labels');
+  });
+
+  it('returns undefined when there are no symbol layers', () => {
+    const { map } = fakeMap([
+      { id: 'background', type: 'background' },
+      { id: 'water', type: 'fill' },
+    ]);
+    expect(findFirstSymbolLayerId(map)).toBeUndefined();
+  });
+
+  it('returns undefined when the style is unavailable', () => {
+    const { map } = fakeMap(undefined);
+    expect(findFirstSymbolLayerId(map)).toBeUndefined();
+  });
+});
+
+describe('emphasizePlaceLabels', () => {
+  it('restyles only the `place` source-layer symbol layers', () => {
+    const { map, calls } = fakeMap([
+      { id: 'roads', type: 'line', 'source-layer': 'transportation' },
+      {
+        id: 'road_labels',
+        type: 'symbol',
+        'source-layer': 'transportation_name',
+      },
+      { id: 'city_labels', type: 'symbol', 'source-layer': 'place' },
+      { id: 'water_labels', type: 'symbol', 'source-layer': 'water_name' },
+    ]);
+    emphasizePlaceLabels(map);
+    const touched = [...new Set(calls.map((c) => c.id))];
+    expect(touched).toEqual(['city_labels']);
+    // Default near-black text + solid white halo.
+    expect(calls).toContainEqual({
+      id: 'city_labels',
+      prop: 'text-color',
+      val: '#1a1a1a',
+    });
+    expect(calls).toContainEqual({
+      id: 'city_labels',
+      prop: 'text-halo-width',
+      val: 1.6,
+    });
+  });
+
+  it('respects custom options', () => {
+    const { map, calls } = fakeMap([
+      { id: 'city_labels', type: 'symbol', 'source-layer': 'place' },
+    ]);
+    emphasizePlaceLabels(map, { textColor: '#000', haloWidth: 2 });
+    expect(calls).toContainEqual({
+      id: 'city_labels',
+      prop: 'text-color',
+      val: '#000',
+    });
+    expect(calls).toContainEqual({
+      id: 'city_labels',
+      prop: 'text-halo-width',
+      val: 2,
+    });
+  });
+
+  it('is a no-op when there are no place labels', () => {
+    const { map, calls } = fakeMap([
+      {
+        id: 'road_labels',
+        type: 'symbol',
+        'source-layer': 'transportation_name',
+      },
+    ]);
+    emphasizePlaceLabels(map);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/components/TileMap/labels.test.ts
+++ b/src/components/TileMap/labels.test.ts
@@ -70,6 +70,13 @@ describe('emphasizePlaceLabels', () => {
       prop: 'text-halo-width',
       val: 1.6,
     });
+    // Pins opacity to 1 so the near-black color isn't faded to gray by the
+    // style's zoom-driven text-opacity ramp.
+    expect(calls).toContainEqual({
+      id: 'city_labels',
+      prop: 'text-opacity',
+      val: 1,
+    });
   });
 
   it('respects custom options', () => {

--- a/src/components/TileMap/labels.ts
+++ b/src/components/TileMap/labels.ts
@@ -31,6 +31,11 @@ export interface EmphasizeLabelsOptions {
  * give them a strong white halo so they stay legible on top of colored data
  * overlays.
  *
+ * The default protomaps style fades place labels with a zoom-driven
+ * `text-opacity` (city labels only reach full strength around zoom 9), so this
+ * also pins `text-opacity` to 1 — otherwise the near-black color reads as gray
+ * at the low-to-mid zooms typical of a choropleth.
+ *
  * Targets the `place` source-layer symbol layers of the default Reuters
  * protomaps style. On a style that doesn't have them it's a **no-op** (the
  * per-layer checks and `try/catch` make it degrade gracefully), so it's safe to
@@ -56,6 +61,7 @@ export function emphasizePlaceLabels(
       map.setPaintProperty(layer.id, 'text-halo-color', haloColor);
       map.setPaintProperty(layer.id, 'text-halo-width', haloWidth);
       map.setPaintProperty(layer.id, 'text-halo-blur', 0);
+      map.setPaintProperty(layer.id, 'text-opacity', 1);
     } catch {
       /* layer isn't paintable in this style; skip it */
     }

--- a/src/components/TileMap/labels.ts
+++ b/src/components/TileMap/labels.ts
@@ -1,0 +1,63 @@
+import type { Map as MaplibreMap } from 'maplibre-gl';
+
+/**
+ * Find the first symbol (label) layer in the map's current style, or undefined.
+ * Symbol layers are the basemap's place names, road labels, etc. Inserting a
+ * data layer *before* this id keeps every label above the data.
+ *
+ * @see https://docs.mapbox.com/mapbox-gl-js/example/geojson-layer-in-stack/
+ */
+export function findFirstSymbolLayerId(map: MaplibreMap): string | undefined {
+  const layers = map.getStyle()?.layers;
+  if (!layers) return undefined;
+  for (const layer of layers) {
+    if (layer.type === 'symbol') return layer.id;
+  }
+  return undefined;
+}
+
+/** Options for {@link emphasizePlaceLabels}. */
+export interface EmphasizeLabelsOptions {
+  /** Text color for place labels. Default `#1a1a1a` (near-black). */
+  textColor?: string;
+  /** Halo color. Default solid white. */
+  haloColor?: string;
+  /** Halo width, in px. Default `1.6`. */
+  haloWidth?: number;
+}
+
+/**
+ * Darken the basemap's populated-place labels (cities, towns, capitals, …) and
+ * give them a strong white halo so they stay legible on top of colored data
+ * overlays.
+ *
+ * Targets the `place` source-layer symbol layers of the default Reuters
+ * protomaps style. On a style that doesn't have them it's a **no-op** (the
+ * per-layer checks and `try/catch` make it degrade gracefully), so it's safe to
+ * call regardless of `styleUrl`.
+ */
+export function emphasizePlaceLabels(
+  map: MaplibreMap,
+  opts: EmphasizeLabelsOptions = {}
+): void {
+  const {
+    textColor = '#1a1a1a',
+    haloColor = 'rgba(255, 255, 255, 1)',
+    haloWidth = 1.6,
+  } = opts;
+  const layers = map.getStyle()?.layers;
+  if (!layers) return;
+  for (const layer of layers) {
+    if (layer.type !== 'symbol') continue;
+    const sourceLayer = (layer as { 'source-layer'?: string })['source-layer'];
+    if (sourceLayer !== 'place') continue;
+    try {
+      map.setPaintProperty(layer.id, 'text-color', textColor);
+      map.setPaintProperty(layer.id, 'text-halo-color', haloColor);
+      map.setPaintProperty(layer.id, 'text-halo-width', haloWidth);
+      map.setPaintProperty(layer.id, 'text-halo-blur', 0);
+    } catch {
+      /* layer isn't paintable in this style; skip it */
+    }
+  }
+}


### PR DESCRIPTION
Ports two small, broadly-useful map behaviors — first built locally in the Reuters climate/heat projects — into `TileMap` as opt-in switches, so any graphic can keep its basemap labels readable over a colored data overlay.

## New props

- **`TileMapLayer` `beneathLabels`** (boolean) — inserts the layer just below the basemap's first symbol (label) layer, so place names stay on top of the fill. This is the ergonomic version of `beforeId`: you don't have to know the style's label-layer id. An explicit `beforeId` still takes precedence.
- **`TileMap` `emphasizeLabels`** (boolean) — on map load, darkens the basemap's `place` labels (near-black) and adds a strong white halo so city/region names punch through a translucent overlay.

Both **degrade gracefully** — they no-op on styles without the expected symbol / `place` layers, so they're safe regardless of `styleUrl`.

<img width="1920" height="1005" alt="Screenshot From 2026-07-01 12-44-25" src="https://github.com/user-attachments/assets/ee95df8a-34d9-45e1-94f8-59e7ab68d7c1" />


## Why here

`beneathLabels` is actually *simpler and more robust* in the library than in app code: `TileMapLayer` owns the `addLayer` call, so it can insert beneath the labels on the first add — no `styledata`/`moveLayer` reassert dance that app-side code needs because it can't set `beforeId` at add-time.

## Included

- Shared helpers in `src/components/TileMap/labels.ts` (`findFirstSymbolLayerId`, `emphasizePlaceLabels` with color/halo options).
- **Unit tests** (`labels.test.ts`, 6 tests, passing).
- A **"Labels above data"** Storybook story — a translucent fill over Iowa with both switches on.
- Docs (`TileMap.mdx`) + a **minor** changeset.

## Notes

- `emphasizeLabels` is intentionally scoped to the default Reuters protomaps `place` labels; a future `labelPaint`-style override could generalize it if needed.
- `emphasizePlaceLabels` accepts `{ textColor, haloColor, haloWidth }` if we later want to expose finer control through the component.