### PR TITLE
feat(Geocoder): configurable minLength and debounceMs

### DIFF
--- a/.changeset/geocoder-debounce-minlength.md
+++ b/.changeset/geocoder-debounce-minlength.md
@@ -1,0 +1,8 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Geocoder: add configurable `minLength` and `debounceMs` props (defaults
+unchanged at 2 chars / 300 ms). Raising them reduces the number of paid Mapbox
+geocoding requests made per search — each keystroke past the debounce window
+bills a request.

--- a/src/components/Geocoder/Geocoder.mdx
+++ b/src/components/Geocoder/Geocoder.mdx
@@ -24,4 +24,6 @@ The `Geocoder` component provides an autocomplete location search powered by the
 
 The `accessToken` prop is required. Look up the Reuters Mapbox token in the team's 1Password vault. All [Mapbox forward geocoding options](https://docs.mapbox.com/api/search/geocoding-v6/#forward-geocoding) are available as props, including `country`, `language`, `types`, `bbox`, `proximity`, `limit`, and `worldview`.
 
+To reduce the number of paid geocoding requests, use `minLength` (minimum characters before searching, default `2`) and `debounceMs` (delay after the last keystroke before requesting, default `300`). Raising them fires fewer requests while the user is still typing.
+
 <Canvas of={GeocoderStories.Demo} />

--- a/src/components/Geocoder/Geocoder.svelte
+++ b/src/components/Geocoder/Geocoder.svelte
@@ -12,12 +12,25 @@
     searchPlaceholder?: string;
     /** Callback fired when a location is selected from the results. */
     onselect?: (location: { lng: number; lat: number; name: string }) => void;
+    /**
+     * Minimum number of characters before a request is made. Raising this
+     * cuts the number of paid geocoding requests per search. Defaults to 2.
+     */
+    minLength?: number;
+    /**
+     * Debounce window in milliseconds between the last keystroke and the
+     * request. Raising this fires fewer requests while the user is still
+     * typing (each request is billed). Defaults to 300.
+     */
+    debounceMs?: number;
   }
 
   let {
     accessToken,
     searchPlaceholder = 'Search for a location',
     onselect,
+    minLength = 2,
+    debounceMs = 300,
     autocomplete = true,
     bbox,
     country,
@@ -49,7 +62,7 @@
     clearTimeout(debounceTimer);
     abortController?.abort();
 
-    if (query.length < 2) {
+    if (query.length < minLength) {
       suggestions = [];
       return;
     }
@@ -78,7 +91,7 @@
         if (e instanceof DOMException && e.name === 'AbortError') return;
         console.error('Geocoder error:', e);
       }
-    }, 300);
+    }, debounceMs);
   }
 
   onDestroy(() => {

--- a/src/components/Geocoder/Geocoder.svelte
+++ b/src/components/Geocoder/Geocoder.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import { geocode, type GeocodeFeature, type GeocodeOptions } from './geocode';
+  import { normalizeMinLength, normalizeDebounceMs } from './normalize';
   import MagnifyingGlass from '../SearchInput/components/MagnifyingGlass.svelte';
   import X from '../SearchInput/components/X.svelte';
 
@@ -57,12 +58,22 @@
   let debounceTimer: ReturnType<typeof setTimeout>;
   let abortController: AbortController | null = null;
 
+  // Normalize the throttling props so a non-numeric value passed via markup
+  // (e.g. `minLength="two"`) can't coerce to NaN and disable the gate — which
+  // would bill a request on every keystroke. Fall back to the documented
+  // defaults, clamped to sane floors.
+  let effectiveMinLength = $derived(normalizeMinLength(minLength));
+  let effectiveDebounceMs = $derived(normalizeDebounceMs(debounceMs));
+
   function handleInput() {
     selectedIndex = -1;
     clearTimeout(debounceTimer);
     abortController?.abort();
 
-    if (query.length < minLength) {
+    // Trim first so whitespace-only input (e.g. "  ") doesn't clear the gate
+    // and bill a request for an empty search.
+    const trimmed = query.trim();
+    if (trimmed.length < effectiveMinLength) {
       suggestions = [];
       return;
     }
@@ -71,7 +82,7 @@
       abortController = new AbortController();
       try {
         suggestions = await geocode(
-          query,
+          trimmed,
           {
             accessToken,
             autocomplete,
@@ -91,7 +102,7 @@
         if (e instanceof DOMException && e.name === 'AbortError') return;
         console.error('Geocoder error:', e);
       }
-    }, debounceMs);
+    }, effectiveDebounceMs);
   }
 
   onDestroy(() => {

--- a/src/components/Geocoder/normalize.test.ts
+++ b/src/components/Geocoder/normalize.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeMinLength, normalizeDebounceMs } from './normalize';
+
+describe('normalizeMinLength', () => {
+  it('keeps a valid integer', () => {
+    expect(normalizeMinLength(3)).toBe(3);
+  });
+
+  it('coerces a numeric string (markup passes strings)', () => {
+    expect(normalizeMinLength('3')).toBe(3);
+  });
+
+  it('floors a fractional value', () => {
+    expect(normalizeMinLength(2.9)).toBe(2);
+  });
+
+  it('falls back for non-numeric, so the gate is never disabled', () => {
+    expect(normalizeMinLength('two')).toBe(2);
+    expect(normalizeMinLength(NaN)).toBe(2);
+    expect(normalizeMinLength(undefined)).toBe(2);
+  });
+
+  it('falls back for sub-1 values (0 would bill empty queries)', () => {
+    expect(normalizeMinLength(0)).toBe(2);
+    expect(normalizeMinLength(-5)).toBe(2);
+  });
+
+  it('honours a custom fallback', () => {
+    expect(normalizeMinLength('nope', 3)).toBe(3);
+  });
+});
+
+describe('normalizeDebounceMs', () => {
+  it('keeps a valid non-negative number', () => {
+    expect(normalizeDebounceMs(500)).toBe(500);
+    expect(normalizeDebounceMs(0)).toBe(0);
+  });
+
+  it('coerces a numeric string', () => {
+    expect(normalizeDebounceMs('500')).toBe(500);
+  });
+
+  it('falls back for non-numeric (NaN would fire on every keystroke)', () => {
+    expect(normalizeDebounceMs('fast')).toBe(300);
+    expect(normalizeDebounceMs(NaN)).toBe(300);
+    expect(normalizeDebounceMs(undefined)).toBe(300);
+  });
+
+  it('falls back for negative values', () => {
+    expect(normalizeDebounceMs(-100)).toBe(300);
+  });
+
+  it('honours a custom fallback', () => {
+    expect(normalizeDebounceMs('nope', 500)).toBe(500);
+  });
+});

--- a/src/components/Geocoder/normalize.ts
+++ b/src/components/Geocoder/normalize.ts
@@ -1,0 +1,27 @@
+/**
+ * Coercion helpers for the Geocoder's request-throttling props.
+ *
+ * These props can arrive as strings when set via markup (e.g.
+ * `minLength="two"`), so a non-numeric value must not be trusted directly: a
+ * `NaN` would disable the length gate or the debounce and bill a Mapbox request
+ * on every keystroke. Both helpers fall back to the documented defaults and
+ * clamp to sane floors.
+ */
+
+/**
+ * Coerce a consumer-supplied `minLength` to a safe integer of at least 1.
+ * Invalid or sub-1 values fall back to `fallback` (default 2).
+ */
+export function normalizeMinLength(value: unknown, fallback = 2): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Coerce a consumer-supplied `debounceMs` to a finite, non-negative number.
+ * Invalid or negative values fall back to `fallback` (default 300).
+ */
+export function normalizeDebounceMs(value: unknown, fallback = 300): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}


### PR DESCRIPTION
Makes the `Geocoder`'s search-throttling knobs configurable so consuming apps can cut paid Mapbox geocoding requests. Both were hard-coded — `query.length < 2` and a 300 ms debounce — so there was no way to tune request volume per app.

## Change
Two new optional props (defaults unchanged, so this is non-breaking):

| Prop | Default | Effect |
|---|---|---|
| `minLength` | `2` | Minimum characters before a request is made |
| `debounceMs` | `300` | Delay after the last keystroke before requesting |

Each keystroke past the debounce window bills a Mapbox request, so raising either value directly reduces cost. Documented in `Geocoder.mdx`; changeset included (minor).

## Context
Part of a Mapbox cost-reduction effort on the Reuters Climate Monitor frontend (a $1,200/mo geocoding bill). The reverse-geocoding fixes landed in that repo directly; this is the shared-library half so the climate app (and any other consumer) can raise the search box to e.g. 500 ms / 3 chars after a release + dep bump.

## Checks
- `pnpm check` (svelte-check): 0 errors / 0 warnings