### PR TITLE
fix: add asChild to composed Storybook stories to prevent double component wrapping

### DIFF
--- a/src/components/BeforeAfter/BeforeAfter.stories.svelte
+++ b/src/components/BeforeAfter/BeforeAfter.stories.svelte
@@ -32,7 +32,7 @@
   }}
 />
 
-<Story name="With text" exportName="WithText">
+<Story asChild name="With text" exportName="WithText">
   <BeforeAfter
     beforeSrc={beforeImg}
     beforeAlt="Satellite image of Russian base at Myrne taken on July 7, 2020."

--- a/src/components/Byline/Byline.stories.svelte
+++ b/src/components/Byline/Byline.stories.svelte
@@ -36,7 +36,7 @@
   }}
 />
 
-<Story name="Customised" tags={['!autodocs', '!dev']}>
+<Story asChild name="Customised" tags={['!autodocs', '!dev']}>
   <Byline publishTime="2021-09-12T00:00:00Z" updateTime="2021-09-12T13:57:00Z">
     {#snippet byline()}
       <strong>BY REUTERS GRAPHICS</strong>

--- a/src/components/GraphicBlock/GraphicBlock.stories.svelte
+++ b/src/components/GraphicBlock/GraphicBlock.stories.svelte
@@ -45,7 +45,7 @@
   </GraphicBlock>
 </Story>
 
-<Story name="Custom text" exportName="CustomText">
+<Story asChild name="Custom text" exportName="CustomText">
   <GraphicBlock>
     <div class="demo-graphic">
       <img src={PlaceholderImg} alt="placeholder" />
@@ -74,7 +74,7 @@
   </GraphicBlock>
 </Story>
 
-<Story name="Custom AREA description" exportName="CustomAriaDescription">
+<Story asChild name="Custom AREA description" exportName="CustomAriaDescription">
   <GraphicBlock
     title="Earthquake in Haiti"
     description="The 7.2-magnitude earthquake struck at 8:29 a.m. EST, Aug. 14, 2021."

--- a/src/components/GraphicBlock/GraphicBlock.stories.svelte
+++ b/src/components/GraphicBlock/GraphicBlock.stories.svelte
@@ -74,7 +74,11 @@
   </GraphicBlock>
 </Story>
 
-<Story asChild name="Custom AREA description" exportName="CustomAriaDescription">
+<Story
+  asChild
+  name="Custom AREA description"
+  exportName="CustomAriaDescription"
+>
   <GraphicBlock
     title="Earthquake in Haiti"
     description="The 7.2-magnitude earthquake struck at 8:29 a.m. EST, Aug. 14, 2021."

--- a/src/components/Headline/Headline.stories.svelte
+++ b/src/components/Headline/Headline.stories.svelte
@@ -45,7 +45,7 @@
   />
 </Story>
 
-<Story name="Custom hed and dek" exportName="CustomHedDek">
+<Story asChild name="Custom hed and dek" exportName="CustomHedDek">
   <Headline width="wide">
     {#snippet hed()}
       <h1 class="custom-hed">
@@ -64,7 +64,7 @@
   </Headline>
 </Story>
 
-<Story name="Crown image" exportName="CrownImage">
+<Story asChild name="Crown image" exportName="CrownImage">
   <Headline
     class="!fmt-3"
     hed="Europa"
@@ -82,7 +82,7 @@
   </Headline>
 </Story>
 
-<Story name="Crown graphic" exportName="CrownGraphic">
+<Story asChild name="Crown graphic" exportName="CrownGraphic">
   <Headline
     width="wider"
     class="!fmt-1"

--- a/src/components/HeroHeadline/HeroHeadline.stories.svelte
+++ b/src/components/HeroHeadline/HeroHeadline.stories.svelte
@@ -211,7 +211,7 @@
   </HeroHeadline>
 </Story>
 
-<Story name="Custom hed" exportName="CustomHed">
+<Story asChild name="Custom hed" exportName="CustomHed">
   <HeroHeadline
     class="custom-hed"
     authors={[

--- a/src/components/InfoBox/InfoBox.stories.svelte
+++ b/src/components/InfoBox/InfoBox.stories.svelte
@@ -41,7 +41,7 @@
     text: "- **Food crisis**: [Russia's invasion of Ukraine](#) in late February dramatically worsened the outlook for already inflated global food prices. \n- **Under fire**: Civillian homes destroyed in the conflict and Russia accused of war crimes. \n- **Nordstream sabotage**: A series of clandestine bombings and subsequent underwater gas leaks occurred on the Nord Stream 1 and Nord Stream 2 natural gas pipelines. ",
   }}
 />
-<Story name="Customised" tags={['!autodocs', '!dev']}>
+<Story asChild name="Customised" tags={['!autodocs', '!dev']}>
   <InfoBox>
     {#snippet header()}
       <h3>Global video game market</h3>

--- a/src/components/Legend/Legend.stories.svelte
+++ b/src/components/Legend/Legend.stories.svelte
@@ -262,7 +262,7 @@
   }}
 />
 
-<Story name="Map Layout" tags={['!autodocs']}>
+<Story asChild name="Map Layout" tags={['!autodocs']}>
   <TileMap
     id="legend-demo-map"
     center={[0, 20]}

--- a/src/components/Video/Video.stories.svelte
+++ b/src/components/Video/Video.stories.svelte
@@ -72,7 +72,7 @@
   }}
 />
 
-<Story name="Text elements" exportName="Text">
+<Story asChild name="Text elements" exportName="Text">
   <Video
     src={SilentVideo}
     ariaDescription="Required description of your video for screen readers."


### PR DESCRIPTION
Several stories nested a component directly inside <Story> without asChild, causing addon-svelte-csf to auto-render the meta component and forward the composed markup as its children instead of rendering it directly.

### What's in this pull request

Tell us what this PR does or link to any related issues that describe the goal here.

### Before submitting, please check that you've ...

- [x] Read our [contributing guide](https://github.com/reuters-graphics/graphics-components/blob/master/CONTRIBUTING.md)
- [ ] Documented any new components or features
- [ ] Tagged an editor to review this PR
