### PR TITLE
feat(SEO): align metadata with Reuters article SEO conventions

### DIFF
--- a/.changeset/seo-improvements.md
+++ b/.changeset/seo-improvements.md
@@ -1,0 +1,16 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Improve `SEO` component to better align with Reuters article SEO conventions:
+
+- Add `robots` (`noarchive, max-image-preview:large`) so search engines show large thumbnail previews, matching reuters.com.
+- Add Open Graph `article:*` tags (`published_time`, `modified_time`, `section`, `author`, `tag`), plus `og:updated_time`, `og:locale`, and `og:image:alt`/`width`/`height`.
+- Add `<meta name="author">` and `news_keywords`.
+- Enrich the `NewsMediaOrganization` JSON-LD with `sameAs`, `address`, `parentOrganization` and editorial-standards policies (publishing principles, ethics, corrections, diversity, fact-checking) as E-E-A-T trust signals; use the 512×512 logo.
+- Add `description` to the `NewsArticle` JSON-LD, and inline the publisher name + logo (in addition to the `@id` link) so the article validates standalone in Google's Rich Results Test.
+- Fix invalid structured data: never emit empty dates (`dateModified` falls back to `publishTime`), omit empty `author`/`creator`, and derive `copyrightYear` from `publishTime` instead of the current date.
+- Resolve relative share image paths to absolute URLs.
+- Add `hreflang` support via a new `alternates` prop for multi-language graphics, emitting `rel="alternate"` links and matching `og:locale:alternate` tags so Google serves the right language per region and treats versions as one story.
+- New optional props: `articleSection`, `keywords`, `locale` (defaults to `en_GB`), `shareImgWidth`, `shareImgHeight`, `alternates`.
+- Switch Twitter handle to `@Reuters`.

--- a/src/components/SEO/SEO.mdx
+++ b/src/components/SEO/SEO.mdx
@@ -30,6 +30,31 @@ The `SEO` component adds essential metadata to pages.
     { name: 'Jane Doe', link: 'https://www.reuters.com/authors/jane-doe/' },
     { name: 'John Doe', link: 'https://www.reuters.com/authors/john-doe/' },
   ]}
+  articleSection="Graphics"
+  keywords={['Reuters graphics', 'COVID-19', 'coronavirus']}
+  locale="en_GB"
+  shareImgWidth={1200}
+  shareImgHeight={630}
+/>
+```
+
+The `articleSection`, `keywords`, `locale`, `shareImgWidth` and `shareImgHeight` props are all optional. Setting the image dimensions and a specific section/keywords improves how the page appears in search results and social/link previews.
+
+## Multi-locale graphics pages
+
+Most graphics ship in a single language, but when a graphic is published in more than one, pass `alternates` to emit [`hreflang`](https://developers.google.com/search/docs/specialty/international/localized-versions) links (and matching `og:locale:alternate` tags). This tells Google to serve the right language in the right region and to treat the versions as one story rather than competing duplicates.
+
+List _every_ language version — including the current page — plus an `x-default` that points to your best fallback (usually the default-language version). Each entry's `hreflang` is a [BCP-47](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) tag.
+
+```svelte
+<SEO
+  {...otherProps}
+  locale="en_GB"
+  alternates={[
+    { hreflang: 'x-default', href: 'https://www.reuters.com/graphics/story/' },
+    { hreflang: 'en-GB', href: 'https://www.reuters.com/graphics/story/' },
+    { hreflang: 'es', href: 'https://www.reuters.com/graphics/story/es/' },
+  ]}
 />
 ```
 
@@ -46,6 +71,9 @@ shareTitle: Page title for social media
 shareDescription: Page description for social media
 shareImgPath: images/reuters-graphics.jpg
 shareImgAlt: Alt text for share image.
+section: World News
+keywords: keywords, separated by, commas
+locale: en_GB
 ```
 
 ... which you'll pass to the `SEO` component.
@@ -60,7 +88,7 @@ shareImgAlt: Alt text for share image.
 </script>
 
 <SEO
-  baseUrl={VITE_BASE_URL}
+  baseUrl={__BASE_URL__}
   pageUrl={$page.url}
   seoTitle={content.seoTitle}
   seoDescription={content.seoDescription}
@@ -71,10 +99,16 @@ shareImgAlt: Alt text for share image.
   publishTime={pkg?.reuters?.graphic?.published}
   updateTime={pkg?.reuters?.graphic?.updated}
   authors={pkg?.reuters?.graphic?.authors}
+  articleSection={content.section}
+  keywords={content.keywords
+    ?.split(',')
+    .map((k) => k.trim())
+    .filter(Boolean)}
+  locale={content.locale}
 />
 ```
 
-> **Note:** For _reasons_, we can't document the value of `VITE_BASE_URL` below. It's `import` + `.meta.env.BASE_URL` (concatenate all that) in the graphics kit and other Vite-based rigs.
+> **Note:** `__BASE_URL__` is a build-time global available throughout graphics kit projects — no import needed. It's the project's fully-qualified base URL (origin + trailing slash), i.e. the address of the project homepage. `SEO` uses it to derive the page's origin for canonical and share tags.
 
 <Canvas of={SEOStories.Demo} />
 ```

--- a/src/components/SEO/SEO.stories.svelte
+++ b/src/components/SEO/SEO.stories.svelte
@@ -19,5 +19,29 @@
     shareDescription: 'A description for Twitter/Facebook',
     shareImgPath:
       'https://www.reuters.com/graphics/world-coronavirus-tracker-and-maps/assets/images/share.jpg',
+    shareImgAlt: 'An image showing global COVID infection rates',
+    shareImgWidth: 1200,
+    shareImgHeight: 630,
+    publishTime: '2020-09-15T00:00:00.000Z',
+    updateTime: '2021-01-10T12:30:00.000Z',
+    articleSection: 'Graphics',
+    keywords: ['Reuters graphics', 'COVID-19', 'coronavirus'],
+    authors: [
+      { name: 'Jane Doe', link: 'https://www.reuters.com/authors/jane-doe/' },
+    ],
+    alternates: [
+      {
+        hreflang: 'x-default',
+        href: 'https://www.reuters.com/graphics/world-coronavirus-tracker-and-maps/',
+      },
+      {
+        hreflang: 'en-GB',
+        href: 'https://www.reuters.com/graphics/world-coronavirus-tracker-and-maps/',
+      },
+      {
+        hreflang: 'es',
+        href: 'https://www.reuters.com/graphics/world-coronavirus-tracker-and-maps/es/',
+      },
+    ],
   }}
 />

--- a/src/components/SEO/SEO.svelte
+++ b/src/components/SEO/SEO.svelte
@@ -5,9 +5,20 @@
     link: string;
   }
 
+  interface AlternateLink {
+    /**
+     * A [BCP-47](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) language tag, e.g. `en-GB`, `es`, or the special value `x-default`.
+     */
+    hreflang: string;
+    /**
+     * Absolute URL of the localized version of this page.
+     */
+    href: string;
+  }
+
   interface Props {
     /**
-     * Base url for the page, which in [Vite-based projects](https://vitejs.dev/guide/build.html#public-base-path) is globally available as `import.meta.env.BASE_URL`.
+     * The project's fully-qualified base URL (origin + trailing slash). Only its origin is used, to build canonical and share URLs. In graphics kit projects this is injected at build time as the global `__BASE_URL__` — no import needed.
      */
     baseUrl: string;
     /**
@@ -50,6 +61,30 @@
      * Array of authors for the piece. Each author object must have `name` and `link` attributes.
      */
     authors?: GraphicAuthor[];
+    /**
+     * Section the story belongs to, e.g. "World", "Business". Used for `article:section` and JSON-LD `articleSection`.
+     */
+    articleSection?: string;
+    /**
+     * Keywords/tags describing the story. Used for `article:tag` and JSON-LD `keywords`.
+     */
+    keywords?: string[];
+    /**
+     * Open Graph locale. Defaults to `en_GB`.
+     */
+    locale?: string;
+    /**
+     * Pixel width of the share image. Improves social/link previews when provided.
+     */
+    shareImgWidth?: number;
+    /**
+     * Pixel height of the share image. Improves social/link previews when provided.
+     */
+    shareImgHeight?: number;
+    /**
+     * Localized versions of this page for [`hreflang`](https://developers.google.com/search/docs/specialty/international/localized-versions) annotations. Each entry needs a `hreflang` (BCP-47 tag or `x-default`) and an absolute `href`. Include an entry for _this_ page too, plus an `x-default`, so every language version lists the full set.
+     */
+    alternates?: AlternateLink[];
   }
 
   let {
@@ -64,7 +99,25 @@
     publishTime = '',
     updateTime = '',
     authors = [],
+    articleSection = 'Graphics',
+    keywords = ['Reuters graphics', 'Reuters', 'graphics', 'Interactives'],
+    locale = 'en_GB',
+    shareImgWidth,
+    shareImgHeight,
+    alternates = [],
   }: Props = $props();
+
+  // og:locale:alternate mirrors the hreflang set (minus x-default and the
+  // current locale), converted from BCP-47 (en-GB) to OG form (en_GB).
+  let ogLocaleAlternates = $derived([
+    ...new Set(
+      alternates
+        .map((a) => a.hreflang)
+        .filter((h) => h && h !== 'x-default')
+        .map((h) => h.replace('-', '_'))
+        .filter((h) => h !== locale)
+    ),
+  ]);
   const getOrigin = (baseUrl: string) => {
     try {
       return new URL(baseUrl).origin;
@@ -81,61 +134,154 @@
     (origin + (pageUrl?.pathname || '')).replace(/index\.html\/$/, '')
   );
 
+  // Resolve the share image to an absolute URL. og:image and JSON-LD require
+  // absolute paths — a relative path silently breaks previews, so fall back to
+  // resolving against the page origin.
+  const resolveUrl = (path: string, origin: string) => {
+    if (!path) return path;
+    try {
+      return new URL(path).href;
+    } catch {
+      if (!origin) return path;
+      return `${origin}${path.startsWith('/') ? '' : '/'}${path}`;
+    }
+  };
+  let shareImg = $derived(resolveUrl(shareImgPath, origin));
+
+  // dateModified falls back to the publish time so we never emit an empty date.
+  let modifiedTime = $derived(updateTime || publishTime);
+
+  // Strip keys whose values are empty ('', undefined, null) or empty arrays so
+  // we never emit invalid/empty structured-data fields.
+  const clean = <T extends Record<string, unknown>>(obj: T) =>
+    Object.fromEntries(
+      Object.entries(obj).filter(
+        ([, v]) =>
+          v !== '' &&
+          v !== undefined &&
+          v !== null &&
+          !(Array.isArray(v) && v.length === 0)
+      )
+    );
+
   const orgLdJson = {
-    '@context': 'http://schema.org',
+    '@context': 'https://schema.org',
     '@type': 'NewsMediaOrganization',
     '@id': 'https://www.reuters.com/#publisher',
     name: 'Reuters',
     logo: {
       '@type': 'ImageObject',
-      url: 'https://s3.reutersmedia.net/resources_v2/images/reuters_social_logo.png',
-      width: '200',
-      height: '200',
+      url: 'https://www.reuters.com/pf/resources/images/reuters/logo-vertical-default-512x512.png',
+      width: 512,
+      height: 512,
     },
     url: 'https://www.reuters.com/',
+    // Social profiles and editorial-standards policies are E-E-A-T / news
+    // trust signals Google weighs for publishers. Values mirror reuters.com.
+    sameAs: [
+      'https://www.facebook.com/Reuters/',
+      'https://x.com/reuters',
+      'https://www.instagram.com/reuters/',
+      'https://www.linkedin.com/company/reuters2/',
+      'https://www.tiktok.com/@reuters',
+      'https://www.youtube.com/user/ReutersVideo',
+    ],
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: 'London, United Kingdom',
+      postalCode: 'E14 5AQ',
+      streetAddress: '5 Canada Square, Canary Wharf',
+    },
+    publishingPrinciples:
+      'https://www.thomsonreuters.com/en/about-us/trust-principles.html',
+    verificationFactCheckingPolicy: 'https://www.reuters.com/fact-check/about/',
+    correctionsPolicy: 'https://reutersagency.com/about/standards-values/',
+    ethicsPolicy:
+      'https://ir.thomsonreuters.com/static-files/f4169de5-ee8c-4c28-9971-75b0baf97365',
+    diversityPolicy:
+      'https://www.thomsonreuters.com/en/about-us/social-impact/social-impact-and-esg-report-2022#c7_Diversity%20%20inclusion',
+    parentOrganization: 'https://www.thomsonreuters.com/en.html',
   };
 
-  let articleLdJson = $derived({
-    '@context': 'http://schema.org',
-    '@type': 'NewsArticle',
-    headline: seoTitle,
-    url: canonicalUrl,
-    mainEntityOfPage: {
-      '@type': 'WebPage',
-      '@id': canonicalUrl,
-    },
-    thumbnailUrl: shareImgPath,
-    image: [
-      {
-        '@context': 'http://schema.org',
-        '@type': 'ImageObject',
-        url: shareImgPath,
+  // Inline the publisher's name + logo (rather than only an @id reference to
+  // the org block) so the NewsArticle validates standalone in Google's Rich
+  // Results Test, which doesn't always merge nodes across script blocks. The
+  // @id keeps it linked to the richer org node above.
+  const inlinePublisher = {
+    '@id': orgLdJson['@id'],
+    '@type': orgLdJson['@type'],
+    name: orgLdJson.name,
+    logo: orgLdJson.logo,
+  };
+
+  let articleImage = $derived(
+    clean({
+      '@context': 'https://schema.org',
+      '@type': 'ImageObject',
+      url: shareImg,
+      width: shareImgWidth,
+      height: shareImgHeight,
+    })
+  );
+
+  let articleLdJson = $derived(
+    clean({
+      '@context': 'https://schema.org',
+      '@type': 'NewsArticle',
+      headline: seoTitle,
+      description: seoDescription,
+      url: canonicalUrl,
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': canonicalUrl,
       },
-    ],
-    publisher: { '@id': 'https://www.reuters.com/#publisher' },
-    copyrightHolder: { '@id': 'https://www.reuters.com/#publisher' },
-    sourceOrganization: { '@id': 'https://www.reuters.com/#publisher' },
-    copyrightYear: new Date().getFullYear(),
-    dateCreated: publishTime,
-    datePublished: publishTime,
-    dateModified: updateTime,
-    author: authors.map(({ name, link }) => ({
-      '@type': 'Person',
-      name,
-      url: link,
-    })),
-    creator: authors.map(({ name }) => name),
-    articleSection: 'Graphics',
-    isAccessibleForFree: true,
-    keywords: ['Reuters graphics', 'Reuters', 'graphics', 'Interactives'],
-  });
+      thumbnailUrl: shareImg,
+      image: shareImg ? [articleImage] : [],
+      publisher: inlinePublisher,
+      copyrightHolder: inlinePublisher,
+      sourceOrganization: inlinePublisher,
+      copyrightYear:
+        publishTime ? new Date(publishTime).getFullYear() : undefined,
+      dateCreated: publishTime,
+      datePublished: publishTime,
+      dateModified: modifiedTime,
+      // NewsArticle requires an author — fall back to the Reuters org when none
+      // are supplied rather than emitting an empty array.
+      author:
+        authors.length ?
+          authors.map(({ name, link }) => ({
+            '@type': 'Person',
+            name,
+            url: link,
+          }))
+        : inlinePublisher,
+      creator: authors.map(({ name }) => name),
+      articleSection,
+      isAccessibleForFree: true,
+      keywords,
+    })
+  );
 </script>
 
 <svelte:head>
   {#key canonicalUrl}
     <title>{seoTitle}</title>
     <meta name="description" content={seoDescription} />
+    <meta name="robots" content="noarchive, max-image-preview:large" />
+    {#each authors as author}
+      <meta name="author" content={author.name} />
+    {/each}
+    {#if keywords.length}
+      <meta name="news_keywords" content={keywords.join(', ')} />
+    {/if}
     <link rel="canonical" href={canonicalUrl} />
+    {#each alternates as alternate}
+      <link
+        rel="alternate"
+        hreflang={alternate.hreflang}
+        href={alternate.href}
+      />
+    {/each}
     <link
       rel="icon"
       type="image/png"
@@ -160,22 +306,52 @@
 
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:type" content="article" />
+    <meta property="og:locale" content={locale} />
+    {#each ogLocaleAlternates as ogLocaleAlternate}
+      <meta property="og:locale:alternate" content={ogLocaleAlternate} />
+    {/each}
     <meta property="og:title" content={shareTitle} itemprop="name" />
     <meta
       property="og:description"
       content={shareDescription}
       itemprop="description"
     />
-    <meta property="og:image" content={shareImgPath} itemprop="image" />
+    <meta property="og:image" content={shareImg} itemprop="image" />
+    {#if shareImgAlt}
+      <meta property="og:image:alt" content={shareImgAlt} />
+    {/if}
+    {#if shareImgWidth}
+      <meta property="og:image:width" content={String(shareImgWidth)} />
+    {/if}
+    {#if shareImgHeight}
+      <meta property="og:image:height" content={String(shareImgHeight)} />
+    {/if}
     <meta property="og:site_name" content="Reuters" />
 
+    {#if publishTime}
+      <meta property="article:published_time" content={publishTime} />
+    {/if}
+    {#if modifiedTime}
+      <meta property="article:modified_time" content={modifiedTime} />
+      <meta property="og:updated_time" content={modifiedTime} />
+    {/if}
+    {#if articleSection}
+      <meta property="article:section" content={articleSection} />
+    {/if}
+    {#each authors as author}
+      <meta property="article:author" content={author.link} />
+    {/each}
+    {#each keywords as keyword}
+      <meta property="article:tag" content={keyword} />
+    {/each}
+
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@ReutersGraphics" />
-    <meta name="twitter:creator" content="@ReutersGraphics" />
+    <meta name="twitter:site" content="@Reuters" />
+    <meta name="twitter:creator" content="@Reuters" />
     <meta name="twitter:domain" content={origin} />
     <meta name="twitter:title" content={shareTitle} />
     <meta name="twitter:description" content={shareDescription} />
-    <meta name="twitter:image" content={shareImgPath} />
+    <meta name="twitter:image" content={shareImg} />
     {#if shareImgAlt}
       <meta name="twitter:image:alt" content={shareImgAlt} />
     {/if}


### PR DESCRIPTION
## What

Audits and upgrades the `SEO` component to bring our graphics stories closer to how standard Reuters text articles are marked up for search — validated against a live reuters.com article `<head>` and NYT, plus Google's current (Dec 2025) Article/News structured-data guidance.

## Changes

**Bug fixes (invalid structured data being emitted today)**
- Never emit empty dates — `dateModified` falls back to `publishTime`, and empty date fields are stripped rather than emitted as `""`.
- Omit empty `author`/`creator` (a `NewsArticle` with `"author":[]` is invalid); fall back to the Reuters org when no authors are supplied.
- Derive `copyrightYear` from `publishTime` instead of `new Date()` (removes a hydration-mismatch risk and wrong-year output).
- Resolve relative share image paths to absolute URLs.

**New / missing tags (aligned with reuters.com)**
- `robots` = `noarchive, max-image-preview:large` (enables large thumbnails in search).
- Open Graph `article:*` (`published_time`, `modified_time`, `section`, `author`, `tag`), `og:updated_time`, `og:locale`, `og:image:alt`/`width`/`height`.
- `<meta name="author">` and `news_keywords`.
- `description` in the `NewsArticle` JSON-LD; publisher name + logo inlined (alongside the `@id` link) so it validates standalone in Google's Rich Results Test.
- Enriched `NewsMediaOrganization` JSON-LD with `sameAs`, `address`, `parentOrganization`, and editorial-standards policies (publishing principles, ethics, corrections, diversity, fact-checking) as E-E-A-T signals; 512×512 logo.

**Multi-language support**
- New `alternates` prop emits `hreflang` links + matching `og:locale:alternate` tags, so Google serves the right language per region and treats versions as one story. Documented as an exception under its own docs subheading.

**New optional props**
- `articleSection`, `keywords`, `locale` (defaults to `en_GB`), `shareImgWidth`, `shareImgHeight`, `alternates`. All backward-compatible.

**Other**
- Twitter handle switched to `@Reuters`.
- Docs updated for the graphics kit's new build-time `__BASE_URL__` global (see reuters-graphics/bluprint_graphics-kit#353), and the ArchieML example trims/guards `keywords`.

## Not in this PR (follow-ups)

The biggest remaining Google **News** levers are kit-level, not component-level: a **News XML sitemap** (`<news:news>`, last ~48h), **Google Publisher Center** setup, and a **visible on-page date/time**. Worth scoping separately in the graphics kit.

## Testing

- `svelte-check` — 0 errors
- JSON-LD edge cases verified (missing dates/authors produce valid output; no empty fields)
- `og:locale:alternate` derivation verified against the story fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)
