### PR TITLE
feat(FaqBox): add collapsible FAQ component

### DIFF
--- a/.changeset/faq-box.md
+++ b/.changeset/faq-box.md
@@ -2,4 +2,4 @@
 '@reuters-graphics/graphics-components': minor
 ---
 
-Add a `FaqBox` component: an accessible, collapsible list of frequently asked questions built on native `<details>`/`<summary>` disclosures. Questions collapse by default and each answer is a markdown string (inline links and emphasis supported). Malformed entries are skipped via the exported `normalizeFaqItems` helper, and the whole section is omitted when no valid items remain. Supports `title`, `width`, `class` and `id` props.
+Add a `FaqBox` component: an accessible, collapsible list of frequently asked questions built on native `<details>`/`<summary>` disclosures. Questions collapse by default and each answer is a markdown string (inline links and emphasis supported). Malformed entries (missing or whitespace-only question or answer) are skipped, and the whole section is omitted when no valid items remain. Supports `title`, `width`, `class` and `id` props.

--- a/.changeset/faq-box.md
+++ b/.changeset/faq-box.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Add a `FaqBox` component: an accessible, collapsible list of frequently asked questions built on native `<details>`/`<summary>` disclosures. Questions collapse by default and each answer is a markdown string (inline links and emphasis supported). Malformed entries are skipped via the exported `normalizeFaqItems` helper, and the whole section is omitted when no valid items remain. Supports `title`, `width`, `class` and `id` props.

--- a/src/components/FaqBox/FaqBox.mdx
+++ b/src/components/FaqBox/FaqBox.mdx
@@ -1,0 +1,62 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as FaqBoxStories from './FaqBox.stories.svelte';
+
+<Meta of={FaqBoxStories} />
+
+# FaqBox
+
+The `FaqBox` component renders a list of frequently asked questions as a stack of collapsible disclosures. Questions are collapsed by default — so the page stays short at rest and expands on demand — and each answer is a markdown string, so inline links and emphasis are supported.
+
+It's built on native `<details>`/`<summary>` elements, which are keyboard- and screen-reader-accessible without extra ARIA wiring.
+
+```svelte
+<script>
+  import { FaqBox } from '@reuters-graphics/graphics-components';
+</script>
+
+<FaqBox
+  faq={[
+    {
+      q: "Why doesn't your data always match other sources?",
+      a: 'Different organisations use different methods, models and reporting windows, so small differences are expected.',
+    },
+    {
+      q: 'How often is this updated?',
+      a: 'The figures refresh automatically throughout the day as new data is published.',
+    },
+  ]}
+/>
+```
+
+<Canvas of={FaqBoxStories.Demo} />
+
+The section heading defaults to "Frequently asked questions" and can be overridden with the `title` prop. Malformed entries (a missing question or answer) are skipped, and the whole section is omitted when no valid items remain.
+
+## Using with ArchieML docs
+
+With the graphics kit, you'll likely get your questions from an ArchieML doc...
+
+```yaml
+# Archie ML doc
+[faq]
+
+q: Why doesn't your data always match other sources?
+a: Different organisations use different methods, models and reporting windows, so small differences are expected.
+
+q: How often is this updated?
+a: The figures refresh automatically throughout the day as new data is published.
+[]
+```
+
+... which you'll pass straight to the `FaqBox` component.
+
+```svelte
+<!-- graphics kit -->
+<script>
+  import { FaqBox } from '@reuters-graphics/graphics-components';
+  import content from '$locales/en/content.json';
+</script>
+
+<FaqBox faq={content.faq} />
+```

--- a/src/components/FaqBox/FaqBox.stories.svelte
+++ b/src/components/FaqBox/FaqBox.stories.svelte
@@ -1,0 +1,49 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import FaqBox from './FaqBox.svelte';
+  import BodyText from '../BodyText/BodyText.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Components/Text elements/FaqBox',
+    component: FaqBox,
+    tags: ['autodocs'],
+    argTypes: {
+      width: {
+        control: 'select',
+        options: ['narrower', 'narrow', 'normal', 'wide', 'wider', 'widest'],
+      },
+    },
+  });
+
+  const faq = [
+    {
+      q: "Why doesn't your data always match other sources?",
+      a: 'Different organisations use different methods, models and reporting windows, so small differences between good-faith estimates are expected. We document our own choices in the methodology.',
+    },
+    {
+      q: 'How often is this updated?',
+      a: 'The figures refresh automatically throughout the day as new data is published. The timestamp at the top of the page shows the most recent update.',
+    },
+    {
+      q: 'Where can I read more about the methodology?',
+      a: 'Our full methodology — including sources and known limitations — is documented [here](https://www.reuters.com/). It explains how each number is calculated.',
+    },
+  ];
+</script>
+
+<Story asChild name="Demo">
+  <BodyText
+    text="Bacon ipsum dolor amet turducken buffalo beef ribs bresaola pancetta ribeye pork belly doner hamburger biltong cupim porchetta chuck ham tenderloin."
+  />
+  <FaqBox {faq} />
+</Story>
+
+<!-- A custom heading and a narrower column. -->
+<Story
+  name="Custom title"
+  tags={['!autodocs', '!dev']}
+  args={{ title: 'Questions readers ask', width: 'narrow', faq }}
+/>
+
+<!-- Empty (or all-malformed) input renders nothing — the section is omitted. -->
+<Story name="Empty" tags={['!autodocs', '!dev']} args={{ faq: [] }} />

--- a/src/components/FaqBox/FaqBox.svelte
+++ b/src/components/FaqBox/FaqBox.svelte
@@ -52,8 +52,10 @@
           Native <details>/<summary> disclosures are keyboard- and
           screen-reader-accessible without extra ARIA wiring. Collapsed by
           default so the section stays short at rest and expands on demand.
+          No key: questions aren't guaranteed unique (CMS/ArchieML content),
+          and the list is only ever replaced wholesale, so index keying is safe.
         -->
-        {#each items as item (item.q)}
+        {#each items as item}
           <details class="faq-item">
             <summary class="faq-question">
               <span class="faq-question-text">{item.q}</span>

--- a/src/components/FaqBox/FaqBox.svelte
+++ b/src/components/FaqBox/FaqBox.svelte
@@ -1,0 +1,149 @@
+<!-- @component `FaqBox` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-text-elements-faqbox--docs) -->
+<script lang="ts">
+  import type { ContainerWidth } from '../@types/global';
+  import type { FaqItem } from './types';
+  import Block from '../Block/Block.svelte';
+  import { Markdown } from '@reuters-graphics/svelte-markdown';
+  import { normalizeFaqItems } from './normalize';
+
+  interface Props {
+    /**
+     * Question/answer pairs. Each answer is a markdown string. Malformed
+     * entries (missing question or answer) are skipped, and the whole section
+     * is omitted when none remain.
+     */
+    faq: FaqItem[];
+    /**
+     * Section heading.
+     */
+    title?: string;
+    /**
+     * Width of the component within the text well.
+     */
+    width?: ContainerWidth;
+    /**
+     * Add extra classes to the block tag to target it with custom CSS.
+     */
+    class?: string;
+    /**
+     * Add an id to the block tag to target it with custom CSS.
+     */
+    id?: string;
+  }
+
+  let {
+    faq,
+    title = 'Frequently asked questions',
+    width = 'normal',
+    class: cls = '',
+    id = '',
+  }: Props = $props();
+
+  // Guard against malformed rows and decide whether to render at all.
+  const items = $derived(normalizeFaqItems(faq));
+</script>
+
+{#if items.length}
+  <aside class="faqbox">
+    <Block {width} {id} class="{cls} faq-block">
+      <h3 class="faq-title">{title}</h3>
+      <div class="faq-list">
+        <!--
+          Native <details>/<summary> disclosures are keyboard- and
+          screen-reader-accessible without extra ARIA wiring. Collapsed by
+          default so the section stays short at rest and expands on demand.
+        -->
+        {#each items as item (item.q)}
+          <details class="faq-item">
+            <summary class="faq-question">
+              <span class="faq-question-text">{item.q}</span>
+              <span class="faq-icon" aria-hidden="true"></span>
+            </summary>
+            <div class="faq-answer">
+              <Markdown source={item.a} />
+            </div>
+          </details>
+        {/each}
+      </div>
+    </Block>
+  </aside>
+{/if}
+
+<style lang="scss">
+  @use '../../scss/mixins' as mixins;
+
+  .faq-title {
+    @include mixins.font-subhed;
+    @include mixins.text-lg;
+    @include mixins.font-semibold;
+    @include mixins.leading-tighter;
+    @include mixins.text-primary;
+    margin: 0 0 0.75rem;
+  }
+
+  .faq-list {
+    margin: 0;
+    border-top: 1px solid var(--theme-colour-brand-rules);
+  }
+
+  .faq-item {
+    border-bottom: 1px solid var(--theme-colour-brand-rules);
+  }
+
+  .faq-question {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    cursor: pointer;
+    list-style: none;
+    padding: 0.75rem 0;
+    @include mixins.font-subhed;
+    @include mixins.text-base;
+    @include mixins.font-regular;
+    @include mixins.leading-tight;
+    @include mixins.text-primary;
+
+    // Hide the default disclosure triangle across browsers.
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &:hover .faq-question-text {
+      text-decoration: underline;
+    }
+  }
+
+  // A CSS chevron that rotates when the item is open — no icon asset needed.
+  .faq-icon {
+    flex: 0 0 auto;
+    width: 0.6rem;
+    height: 0.6rem;
+    margin-top: 0.15rem;
+    border-right: 2px solid var(--theme-colour-text-secondary);
+    border-bottom: 2px solid var(--theme-colour-text-secondary);
+    transform: rotate(45deg);
+    transition: transform 0.2s ease;
+  }
+
+  .faq-item[open] .faq-icon {
+    transform: rotate(-135deg);
+  }
+
+  .faq-answer {
+    padding: 0 0 0.75rem;
+
+    :global(p) {
+      @include mixins.font-note;
+      @include mixins.text-sm;
+      @include mixins.font-light;
+      @include mixins.leading-tight;
+      @include mixins.text-secondary;
+      margin: 0 0 0.5rem;
+    }
+
+    :global(p:last-child) {
+      margin-bottom: 0;
+    }
+  }
+</style>

--- a/src/components/FaqBox/normalize.test.ts
+++ b/src/components/FaqBox/normalize.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeFaqItems } from './normalize';
+
+describe('normalizeFaqItems', () => {
+  it('keeps well-formed question/answer pairs', () => {
+    const faq = [
+      { q: 'What is this?', a: 'A test.' },
+      { q: 'And this?', a: 'Another test.' },
+    ];
+    expect(normalizeFaqItems(faq)).toEqual(faq);
+  });
+
+  it('trims whitespace around the question but leaves the answer intact', () => {
+    // Answers are markdown, where leading/trailing whitespace can be
+    // significant (e.g. list or code formatting), so only the question trims.
+    expect(normalizeFaqItems([{ q: '  Padded?  ', a: '  Kept.  ' }])).toEqual([
+      { q: 'Padded?', a: '  Kept.  ' },
+    ]);
+  });
+
+  it('drops items missing a question or an answer', () => {
+    const faq = [
+      { q: 'Has both', a: 'Yes' },
+      { q: 'No answer' },
+      { a: 'No question' },
+    ];
+    expect(normalizeFaqItems(faq)).toEqual([{ q: 'Has both', a: 'Yes' }]);
+  });
+
+  it('drops items whose question or answer is empty or whitespace-only', () => {
+    const faq = [
+      { q: '   ', a: 'Empty question' },
+      { q: 'Empty answer', a: '   ' },
+      { q: 'Fine', a: 'Fine' },
+    ];
+    expect(normalizeFaqItems(faq)).toEqual([{ q: 'Fine', a: 'Fine' }]);
+  });
+
+  it('ignores non-object rows', () => {
+    // The signature accepts `unknown`, so malformed rows need no casts.
+    const faq = [null, undefined, 'nope', 42, { q: 'Real', a: 'Row' }];
+    expect(normalizeFaqItems(faq)).toEqual([{ q: 'Real', a: 'Row' }]);
+  });
+
+  it('returns an empty array for non-array input, so the section is omitted', () => {
+    expect(normalizeFaqItems(undefined)).toEqual([]);
+    expect(normalizeFaqItems(null)).toEqual([]);
+    expect(normalizeFaqItems('faq')).toEqual([]);
+  });
+});

--- a/src/components/FaqBox/normalize.ts
+++ b/src/components/FaqBox/normalize.ts
@@ -1,0 +1,30 @@
+import type { FaqItem } from './types';
+
+/**
+ * Filter a raw `faq` prop down to the items worth rendering.
+ *
+ * Markup and ArchieML docs can pass through malformed entries — a missing
+ * answer, a whitespace-only question, or a non-object row — which would
+ * otherwise render as empty, un-openable disclosures. This keeps only rows
+ * that have both a question and an answer once trimmed, and trims the question
+ * so the summary text has no stray leading/trailing whitespace. Answers are
+ * left untouched so markdown (which is whitespace-sensitive) is preserved.
+ *
+ * Non-array input returns an empty array so the section is omitted entirely.
+ */
+export const normalizeFaqItems = (faq: unknown): FaqItem[] => {
+  if (!Array.isArray(faq)) return [];
+
+  return faq.reduce<FaqItem[]>((items, item) => {
+    if (!item || typeof item !== 'object') return items;
+
+    const { q, a } = item as Partial<FaqItem>;
+    if (typeof q !== 'string' || typeof a !== 'string') return items;
+
+    const question = q.trim();
+    if (!question || !a.trim()) return items;
+
+    items.push({ q: question, a });
+    return items;
+  }, []);
+};

--- a/src/components/FaqBox/types.ts
+++ b/src/components/FaqBox/types.ts
@@ -1,0 +1,12 @@
+/**
+ * A single question/answer pair rendered by the `FaqBox` component.
+ */
+export interface FaqItem {
+  /** The question, shown as the always-visible disclosure summary. */
+  q: string;
+  /**
+   * The answer as a markdown string, revealed when the item is expanded.
+   * Inline links and emphasis are supported.
+   */
+  a: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ export { default as Byline } from './components/Byline/Byline.svelte';
 export { default as DatawrapperChart } from './components/DatawrapperChart/DatawrapperChart.svelte';
 export { default as DocumentCloud } from './components/DocumentCloud/DocumentCloud.svelte';
 export { default as EmbedPreviewerLink } from './components/EmbedPreviewerLink/EmbedPreviewerLink.svelte';
+export { default as FaqBox } from './components/FaqBox/FaqBox.svelte';
+export type { FaqItem } from './components/FaqBox/types';
 export { default as FeaturePhoto } from './components/FeaturePhoto/FeaturePhoto.svelte';
 export { default as Framer } from './components/Framer/Framer.svelte';
 export { default as Geocoder } from './components/Geocoder/Geocoder.svelte';


### PR DESCRIPTION
## What

Adds a new `FaqBox` component: an accessible, collapsible list of frequently asked questions.

- Renders question/answer pairs as native `<details>`/`<summary>` disclosures, collapsed by default.
- Answers are markdown strings (inline links + emphasis), rendered with the same `Markdown` component `InfoBox`/`EndNotes` use.
- Props: `faq`, `title` (defaults to "Frequently asked questions"), `width`, `class`, `id` — mirroring `InfoBox`.
- A pure `normalizeFaqItems` helper filters out malformed rows (missing/whitespace-only question or answer) and omits the whole section when none remain.

<img width="806" height="567" alt="Screenshot From 2026-07-21 16-32-22" src="https://github.com/user-attachments/assets/43ad705c-8477-4afe-b080-7e3bf84fa910" />

## Conformance with library conventions

- **Styling** uses the SCSS token mixins (`font-subhed`, `text-lg`, `text-primary`, etc.) rather than raw `var(--theme-*)`, so it tracks the theme like other components. The chevron border and rules still read `--theme-colour-*` directly (no mixin exists for arbitrary borders).
- Wrapped in `<Block>` with the standard `@component` docs-link comment.
- Ships **Storybook stories** (`Components/Text elements/FaqBox`) and an **MDX** page with a graphics-kit + ArchieML usage example.
- Exported from `src/index.ts` (component + `FaqItem` type).
- Includes a **minor changeset**.

## Testing

- New `normalize.test.ts`: 6 passing unit tests (the library's pure-logic test style).
- `pnpm check` (svelte-check): 0 errors, no new warnings.
- `eslint` + `prettier`: clean.
- `pnpm build` (svelte-package + publint): all good.

## Origin

Ported from a bespoke `FaqBox` in the reuters-climate-monitor-frontend app, generalised for library use (removed climate-specific copy, added input hardening, prop surface, and token-mixin styling).