### PR TITLE
feat: add EmbedMetadata component

### DIFF
--- a/.changeset/embed-metadata.md
+++ b/.changeset/embed-metadata.md
@@ -1,0 +1,7 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+Add `EmbedMetadata` component, a stripped-down alternative to `SEO` for embed pages. It sets a canonical link, `og:url`, `og:image` and a `noindex, nofollow, noarchive` robots tag, and mounts a `PymChild` instance for embed resizing.
+
+Move the `SEO` and `EmbedMetadata` stories into a new `Components/Page metadata` category in Storybook.

--- a/src/components/EmbedMetadata/EmbedMetadata.mdx
+++ b/src/components/EmbedMetadata/EmbedMetadata.mdx
@@ -1,0 +1,65 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as EmbedMetadataStories from './EmbedMetadata.stories.svelte';
+
+<Meta of={EmbedMetadataStories} />
+
+# EmbedMetadata
+
+The `EmbedMetadata` component adds the essential metadata for **embed pages** and wires up a [Pym.js](https://blog.apps.npr.org/pym.js/) child instance so the embed can resize itself inside its parent frame.
+
+```svelte
+<script>
+  import { EmbedMetadata } from '@reuters-graphics/graphics-components';
+</script>
+
+<EmbedMetadata
+  baseUrl="https://www.reuters.com/graphics/world-coronavirus-tracker-and-maps"
+  pageUrl={new URL(
+    'https://www.reuters.com/graphics/world-coronavirus-tracker-and-maps/embeds/en/global-cases/'
+  )}
+  previewImgPath="https://www.reuters.com/graphics/world-coronavirus-tracker-and-maps/assets/images/share.jpg"
+  polling={500}
+/>
+```
+
+The `polling` prop is passed straight through to the [`PymChild`](/docs/components-utilities-pymchild--docs) component that `EmbedMetadata` renders — you don't need to add `PymChild` separately.
+
+Because `EmbedMetadata` already mounts a Pym.js child, you can access it via `pym` elsewhere to send custom height updates to the parent frame:
+
+```svelte
+<script>
+  import { EmbedMetadata, pym } from '@reuters-graphics/graphics-components';
+
+  const updateHeight = () => {
+    if (pym.child) pym.child.sendHeight();
+  };
+</script>
+
+<EmbedMetadata {...props} />
+
+<button onclick={updateHeight}>Update height</button>
+```
+
+## Using with the graphics kit
+
+**Use this component on every embed page in the graphics kit** _instead of_ the [`SEO`](/docs/components-page-metadata-seo--docs) component, which is meant for full, standalone pages. Embeds live inside a parent article, so they don't need the full set of SEO tags, JSON-LD structured data or article metadata `SEO` provides — and they must never be indexed on their own. `EmbedMetadata` sets only what an embed needs: a canonical link and `og:url`, an `og:image`, and a `noindex, nofollow, noarchive` robots tag.
+
+```svelte
+<!-- pages/embeds/en/map/+page.svelte -->
+<script>
+  import { EmbedMetadata } from '@reuters-graphics/graphics-components';
+  import { asset } from '$app/paths';
+  import { page } from '$app/stores';
+</script>
+
+<EmbedMetadata
+  baseUrl={__BASE_URL__}
+  pageUrl={$page.url}
+  previewImgPath={asset(`/images/my-embed-preview.jpg`)}
+/>
+```
+
+> **Note:** `__BASE_URL__` is a build-time global available throughout graphics kit projects — no import needed. It's the project's fully-qualified base URL (origin + trailing slash), i.e. the address of the project homepage. `EmbedMetadata` uses it to derive the page's origin for the canonical and share tags.
+
+<Canvas of={EmbedMetadataStories.Demo} />

--- a/src/components/EmbedMetadata/EmbedMetadata.stories.svelte
+++ b/src/components/EmbedMetadata/EmbedMetadata.stories.svelte
@@ -1,0 +1,23 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import EmbedMetadata from './EmbedMetadata.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Components/Page metadata/EmbedMetadata',
+    component: EmbedMetadata,
+  });
+</script>
+
+<div>View page source to see the embed metadata.</div>
+<Story
+  name="Demo"
+  args={{
+    baseUrl: 'https://www.reuters.com',
+    pageUrl: new URL(
+      'https://www.reuters.com/graphics/world-coronavirus-tracker-and-maps/embeds/global-cases/'
+    ),
+    previewImgPath:
+      'https://www.reuters.com/graphics/world-coronavirus-tracker-and-maps/assets/images/share.jpg',
+    polling: 500,
+  }}
+/>

--- a/src/components/EmbedMetadata/EmbedMetadata.svelte
+++ b/src/components/EmbedMetadata/EmbedMetadata.svelte
@@ -1,0 +1,72 @@
+<!--
+  @component Renders the minimal metadata an embed (iframe) page needs — canonical link, `og:image`, and a `noindex, nofollow, noarchive` robots tag — and mounts a Pym.js child so the embed resizes inside its parent frame. Use instead of `SEO` on embed pages.
+  
+  [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-page-metadata-embedmetadata--docs) 
+-->
+<script lang="ts">
+  import PymChild from '../PymChild/PymChild.svelte';
+
+  interface Props {
+    /**
+     * The project's fully-qualified base URL (origin + trailing slash). Only its origin is used, to build the canonical and og:url tags. In graphics kit projects this is injected at build time as the global `__BASE_URL__` — no import needed.
+     */
+    baseUrl: string;
+    /**
+     * [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object for the page.
+     */
+    pageUrl: URL;
+    /**
+     * Path to an image used to preview the embed in Reuters Connect. **Must be an absolute path.**
+     */
+    previewImgPath: string;
+    /**
+     * Pym.js polling interval, passed through to the `PymChild` component.
+     */
+    polling?: number;
+  }
+
+  let { baseUrl, pageUrl, previewImgPath, polling = 500 }: Props = $props();
+
+  const getOrigin = (baseUrl: string) => {
+    try {
+      return new URL(baseUrl).origin;
+    } catch {
+      // This handles a weird case where Vite's base path is
+      // reset to './' after the app hydrates...
+      if (typeof window !== 'undefined') return getOrigin(window.location.href);
+      return '';
+    }
+  };
+
+  let origin = $derived(getOrigin(baseUrl));
+  let canonicalUrl = $derived(
+    (origin + (pageUrl?.pathname || '')).replace(/index\.html\/$/, '')
+  );
+
+  // Resolve the share image to an absolute URL. og:image requires an absolute
+  // path — a relative path silently breaks previews, so fall back to resolving
+  // against the page origin.
+  const resolveUrl = (path: string, origin: string) => {
+    if (!path) return path;
+    try {
+      return new URL(path).href;
+    } catch {
+      if (!origin) return path;
+      return `${origin}${path.startsWith('/') ? '' : '/'}${path}`;
+    }
+  };
+  let previewImg = $derived(resolveUrl(previewImgPath, origin));
+</script>
+
+<svelte:head>
+  {#key canonicalUrl}
+    <!-- Embeds live inside a parent article and must never be indexed on
+    their own. -->
+    <meta name="robots" content="noindex, nofollow, noarchive" />
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:image" content={previewImg} />
+  {/key}
+</svelte:head>
+
+<PymChild {polling} />

--- a/src/components/SEO/SEO.stories.svelte
+++ b/src/components/SEO/SEO.stories.svelte
@@ -3,7 +3,7 @@
   import SEO from './SEO.svelte';
 
   const { Story } = defineMeta({
-    title: 'Components/Ads & analytics/SEO',
+    title: 'Components/Page metadata/SEO',
     component: SEO,
   });
 </script>

--- a/src/components/SEO/SEO.svelte
+++ b/src/components/SEO/SEO.svelte
@@ -1,4 +1,8 @@
-<!-- @component `SEO` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-ads-analytic-seo--docs) -->
+<!-- 
+  @component Renders the full suite of SEO and social-sharing metadata (title, description, Open Graph, Twitter cards, JSON-LD structured data) for standalone graphics pages on reuters.com. For embed/iframe pages use `EmbedMetadata` instead.
+
+  [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-page-metadata-seo--docs)
+-->
 <script lang="ts">
   interface GraphicAuthor {
     name: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export { default as BodyText } from './components/BodyText/BodyText.svelte';
 export { default as Byline } from './components/Byline/Byline.svelte';
 export { default as DatawrapperChart } from './components/DatawrapperChart/DatawrapperChart.svelte';
 export { default as DocumentCloud } from './components/DocumentCloud/DocumentCloud.svelte';
+export { default as EmbedMetadata } from './components/EmbedMetadata/EmbedMetadata.svelte';
 export { default as EmbedPreviewerLink } from './components/EmbedPreviewerLink/EmbedPreviewerLink.svelte';
 export { default as FaqBox } from './components/FaqBox/FaqBox.svelte';
 export type { FaqItem } from './components/FaqBox/types';


### PR DESCRIPTION
## Summary

Adds a new **`EmbedMetadata`** component — a stripped-down alternative to `SEO` intended for **embed (iframe) pages** in the graphics kit.

Unlike `SEO`, embeds live inside a parent article, so they don't need the full metadata suite (JSON-LD, article tags, Twitter cards, hreflang) and must never be indexed on their own. `EmbedMetadata` renders only:

- a `noindex, nofollow, noarchive` robots tag
- a canonical `<link>` + `og:url`
- an `og:image`

It also mounts a `PymChild` instance (with `polling` passed through), so embeds resize inside their parent frame without adding `<PymChild>` separately.

## Also in this PR

- Moves both `SEO` and `EmbedMetadata` stories into a new **Components/Page metadata** Storybook category (updating the doc-site deep links, and fixing a pre-existing slug typo in `SEO`).
- Rewrites the `@component` descriptions on both components so the LLM-docs table makes the "which one do I use" boundary explicit between standalone-page `SEO` and embed-page `EmbedMetadata`.

## Notes

- Exported from `src/index.ts` as `EmbedMetadata`.
- Patch changeset included.
- `svelte-check` passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)