### PR TITLE
fix(TileMapCallout): restore compact default leader line and make it configurable

### DIFF
--- a/.changeset/tile-map-callout-leader-defaults.md
+++ b/.changeset/tile-map-callout-leader-defaults.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+`TileMapCallout`: restore the compact leader line as the default and make it configurable. The leader now defaults to a 14×14px line with a 3px dot (matching the original callout it replaced) instead of the longer 32×28px/4px line. New `leaderWidth`, `leaderHeight` and `dotRadius` props (all in px) tune the leader per callout, and the SVG geometry and the surface's offset are now derived from a single source so they can no longer drift apart.

--- a/src/components/TileMapCallout/TileMapCallout.mdx
+++ b/src/components/TileMapCallout/TileMapCallout.mdx
@@ -28,3 +28,20 @@ A labelled callout for [`TileMap`](/docs/components-graphics-tilemap--docs). Dro
 Use `placement` (`above` or `below`) and `flip` to position the label around its anchor so it stays clear of nearby map features or the viewport edges. Pass any content as children — a short string or richer markup.
 
 <Canvas of={TileMapCalloutStories.PlacementAndFlip} />
+
+## Leader geometry
+
+The leader line and marker dot default to a compact 14×14px line with a 3px dot. Tune them per callout with the `leaderWidth`, `leaderHeight` and `dotRadius` props (all in px). The callout surface's offset from the dot is derived from `leaderWidth`, so the line and the label stay aligned at any size.
+
+```svelte
+<TileMapCallout
+  lngLat={[-73.9868, 40.7567]}
+  leaderWidth={40}
+  leaderHeight={32}
+  dotRadius={5}
+>
+  Long leader
+</TileMapCallout>
+```
+
+<Canvas of={TileMapCalloutStories.CustomLeaderGeometry} />

--- a/src/components/TileMapCallout/TileMapCallout.mdx
+++ b/src/components/TileMapCallout/TileMapCallout.mdx
@@ -32,6 +32,7 @@ Use `placement` (`above` or `below`) and `flip` to position the label around its
 ## Leader geometry
 
 The leader line and marker dot default to a compact 14×14px line with a 3px dot. Tune them per callout with the `leaderWidth`, `leaderHeight` and `dotRadius` props (all in px). The callout surface's offset from the dot is derived from `leaderWidth`, so the line and the label stay aligned at any size.
+When values collapse to `0`, the component clamps the SVG canvas to a positive size (at least the dot diameter, and at least `1px`) so the SVG/viewBox can’t collapse to `0`.
 
 ```svelte
 <TileMapCallout

--- a/src/components/TileMapCallout/TileMapCallout.stories.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.stories.svelte
@@ -22,6 +22,20 @@
         control: 'boolean',
         description: 'Flip the callout surface to the left of the coordinate.',
       },
+      leaderWidth: {
+        control: { type: 'number', min: 0 },
+        description:
+          'Leader-line width in px — horizontal distance from the dot to the surface.',
+      },
+      leaderHeight: {
+        control: { type: 'number', min: 0 },
+        description:
+          'Leader-line height in px — vertical rise/drop of the diagonal.',
+      },
+      dotRadius: {
+        control: { type: 'number', min: 0 },
+        description: 'Marker dot radius in px.',
+      },
     },
   });
 </script>
@@ -61,6 +75,37 @@
     </TileMapCallout>
     <TileMapCallout lngLat={[-73.9819, 40.7681]} placement="below" flip>
       Below + flipped
+    </TileMapCallout>
+  </TileMap>
+</Story>
+
+<Story asChild name="Custom leader geometry" tags={['!autodocs', '!dev']}>
+  <TileMap
+    id="tile-map-callout-leader-demo"
+    center={[-73.9868, 40.7567]}
+    zoom={13}
+    interactive={true}
+    title="Custom leader geometry"
+    description="Tune the leader line and dot with the leaderWidth, leaderHeight and dotRadius props. The surface offset and the SVG stay in sync."
+    height="500px"
+  >
+    <TileMapCallout lngLat={[-73.9868, 40.7567]}>
+      Default (14×14, dot 3)
+    </TileMapCallout>
+    <TileMapCallout
+      lngLat={[-73.9776, 40.7527]}
+      leaderWidth={40}
+      leaderHeight={32}
+      dotRadius={5}
+    >
+      Long leader (40×32, dot 5)
+    </TileMapCallout>
+    <TileMapCallout
+      lngLat={[-73.9942, 40.7505]}
+      leaderWidth={6}
+      leaderHeight={6}
+    >
+      Short leader (6×6)
     </TileMapCallout>
   </TileMap>
 </Story>

--- a/src/components/TileMapCallout/TileMapCallout.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.svelte
@@ -133,12 +133,13 @@ placement and lifecycle through the map context.
     class?: string;
     /** Add an id to the MapLibre marker wrapper. */
     id?: string;
-    /**
-     * Leader-line width in px — the horizontal distance from the marker dot to
-     * the callout surface. Also sets the surface's offset from the dot so the
-     * line and surface always line up. Defaults to `14`.
-     */
-    leaderWidth?: number;
+/**
+ * Leader-line width in px — horizontal distance from the dot edge to the callout
+ * surface. Values are normalized to non-negative finite numbers; when the
+ * requested width would collapse the SVG (e.g. `0`), it is clamped to at least
+ * the dot diameter (and at least `1px`) so the dot/offset stay aligned.
+ * Defaults to `14`.
+ */
     /**
      * Leader-line height in px — the vertical distance the diagonal rises
      * (`placement="above"`) or drops (`placement="below"`). Defaults to `14`.

--- a/src/components/TileMapCallout/TileMapCallout.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.svelte
@@ -55,6 +55,23 @@ placement and lifecycle through the map context.
 
     return isFiniteNumber(lng) && isFiniteNumber(lat) ? [lng, lat] : null;
   };
+
+  /** Default leader-line width in px: horizontal distance from the marker dot to the callout surface. */
+  export const DEFAULT_TILE_MAP_CALLOUT_LEADER_WIDTH = 14;
+  /** Default leader-line height in px: vertical distance the diagonal rises or drops. */
+  export const DEFAULT_TILE_MAP_CALLOUT_LEADER_HEIGHT = 14;
+  /** Default marker dot radius in px. */
+  export const DEFAULT_TILE_MAP_CALLOUT_DOT_RADIUS = 3;
+
+  /**
+   * Coerce a geometry prop (leader width/height, dot radius) to a non-negative,
+   * finite number, falling back to the supplied default when the value is
+   * missing, non-numeric, negative or non-finite.
+   */
+  export const normalizeTileMapCalloutDimension = (
+    value: unknown,
+    fallback: number
+  ): number => (isFiniteNumber(value) && value >= 0 ? value : fallback);
 </script>
 
 <script lang="ts">
@@ -76,6 +93,19 @@ placement and lifecycle through the map context.
     class?: string;
     /** Add an id to the MapLibre marker wrapper. */
     id?: string;
+    /**
+     * Leader-line width in px — the horizontal distance from the marker dot to
+     * the callout surface. Also sets the surface's offset from the dot so the
+     * line and surface always line up. Defaults to `14`.
+     */
+    leaderWidth?: number;
+    /**
+     * Leader-line height in px — the vertical distance the diagonal rises
+     * (`placement="above"`) or drops (`placement="below"`). Defaults to `14`.
+     */
+    leaderHeight?: number;
+    /** Marker dot radius in px. Defaults to `3`. */
+    dotRadius?: number;
   }
 
   let {
@@ -85,6 +115,9 @@ placement and lifecycle through the map context.
     flip = false,
     class: cls = '',
     id = '',
+    leaderWidth = DEFAULT_TILE_MAP_CALLOUT_LEADER_WIDTH,
+    leaderHeight = DEFAULT_TILE_MAP_CALLOUT_LEADER_HEIGHT,
+    dotRadius = DEFAULT_TILE_MAP_CALLOUT_DOT_RADIUS,
   }: Props = $props();
 
   const mapStore = getContext<Writable<MaplibreMap | null>>('map');
@@ -93,14 +126,39 @@ placement and lifecycle through the map context.
     throw new Error('TileMapCallout must be used inside a TileMap component');
   }
 
-  const lineWidth = 32;
-  const lineHeight = 28;
-  const dotRadius = 4;
-  const svgHeight = lineHeight + dotRadius * 2;
-  const dotCx = dotRadius;
-  const dotCxFlipped = lineWidth - dotRadius;
-  const dotCyAbove = svgHeight - dotRadius;
-  const dotCyBelow = dotRadius;
+  // Leader geometry is derived from props so the SVG dimensions and the CSS
+  // custom properties below share a single source of truth (previously these
+  // were duplicated hardcoded constants that could — and did — drift apart).
+  let safeLeaderWidth = $derived(
+    normalizeTileMapCalloutDimension(
+      leaderWidth,
+      DEFAULT_TILE_MAP_CALLOUT_LEADER_WIDTH
+    )
+  );
+  let safeLeaderHeight = $derived(
+    normalizeTileMapCalloutDimension(
+      leaderHeight,
+      DEFAULT_TILE_MAP_CALLOUT_LEADER_HEIGHT
+    )
+  );
+  let safeDotRadius = $derived(
+    normalizeTileMapCalloutDimension(
+      dotRadius,
+      DEFAULT_TILE_MAP_CALLOUT_DOT_RADIUS
+    )
+  );
+  let svgHeight = $derived(safeLeaderHeight + safeDotRadius * 2);
+  let dotCx = $derived(safeDotRadius);
+  let dotCxFlipped = $derived(safeLeaderWidth - safeDotRadius);
+  let dotCyAbove = $derived(svgHeight - safeDotRadius);
+  let dotCyBelow = $derived(safeDotRadius);
+  // Feed the same values to the CSS via custom properties on the callout root:
+  // `--tile-map-callout-leader-width` sets the surface's inline offset and
+  // `--tile-map-callout-dot-radius` anchors the transform onto the dot.
+  let calloutStyle = $derived(
+    `--tile-map-callout-leader-width: ${safeLeaderWidth}px; ` +
+      `--tile-map-callout-dot-radius: ${safeDotRadius}px;`
+  );
 
   let markerElement: HTMLDivElement;
   let marker: Marker | null = null;
@@ -156,7 +214,7 @@ placement and lifecycle through the map context.
   data-flip={safeFlip ? 'true' : 'false'}
   data-has-coordinates={safeLngLat ? 'true' : 'false'}
 >
-  <div class={calloutClasses}>
+  <div class={calloutClasses} style={calloutStyle}>
     <div class="callout-surface">
       {#if children}
         {@render children()}
@@ -164,16 +222,16 @@ placement and lifecycle through the map context.
     </div>
     <div class="leader-line" aria-hidden="true">
       <svg
-        width={lineWidth}
+        width={safeLeaderWidth}
         height={svgHeight}
-        viewBox="0 0 {lineWidth} {svgHeight}"
+        viewBox="0 0 {safeLeaderWidth} {svgHeight}"
         focusable="false"
       >
         {#if isBelow}
           <line
             x1={safeFlip ? dotCxFlipped : dotCx}
             y1={dotCyBelow}
-            x2={safeFlip ? 0 : lineWidth}
+            x2={safeFlip ? 0 : safeLeaderWidth}
             y2={svgHeight}
             stroke="currentColor"
             stroke-width="1"
@@ -182,14 +240,14 @@ placement and lifecycle through the map context.
           <circle
             cx={safeFlip ? dotCxFlipped : dotCx}
             cy={dotCyBelow}
-            r={dotRadius}
+            r={safeDotRadius}
             fill="currentColor"
           />
         {:else}
           <line
             x1={safeFlip ? dotCxFlipped : dotCx}
             y1={dotCyAbove}
-            x2={safeFlip ? 0 : lineWidth}
+            x2={safeFlip ? 0 : safeLeaderWidth}
             y2={0}
             stroke="currentColor"
             stroke-width="1"
@@ -198,7 +256,7 @@ placement and lifecycle through the map context.
           <circle
             cx={safeFlip ? dotCxFlipped : dotCx}
             cy={dotCyAbove}
-            r={dotRadius}
+            r={safeDotRadius}
             fill="currentColor"
           />
         {/if}
@@ -220,8 +278,12 @@ placement and lifecycle through the map context.
   }
 
   .tile-map-callout {
-    --tile-map-callout-dot-radius: 4px;
-    --tile-map-callout-leader-width: 32px;
+    /* `--tile-map-callout-leader-width` and `--tile-map-callout-dot-radius`
+       are set inline from the `leaderWidth`/`dotRadius` props (see the script)
+       so geometry has a single source of truth; the values here are the
+       matching fallbacks. Colour/shadow/max-width vars remain the theming API. */
+    --tile-map-callout-dot-radius: 3px;
+    --tile-map-callout-leader-width: 14px;
     --tile-map-callout-surface-max-width: min(14rem, calc(100vw - 2rem));
     --tile-map-callout-surface-background: var(--theme-colour-background, #fff);
     --tile-map-callout-colour: var(--theme-colour-text-primary, #404040);

--- a/src/components/TileMapCallout/TileMapCallout.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.svelte
@@ -72,6 +72,46 @@ placement and lifecycle through the map context.
     value: unknown,
     fallback: number
   ): number => (isFiniteNumber(value) && value >= 0 ? value : fallback);
+
+  export interface TileMapCalloutGeometry {
+    /** SVG canvas width and the surface's inline offset from the dot (px). */
+    leaderWidth: number;
+    /** SVG canvas height (px). */
+    svgHeight: number;
+    /** Dot centre x for the default (non-flipped) side. */
+    dotCx: number;
+    /** Dot centre x when flipped to the right of the surface. */
+    dotCxFlipped: number;
+    /** Dot centre y for `placement="above"`. */
+    dotCyAbove: number;
+    /** Dot centre y for `placement="below"`. */
+    dotCyBelow: number;
+  }
+
+  /**
+   * Resolve the leader-line SVG geometry from normalized dimensions. The canvas
+   * span is clamped to a positive size (at least the dot diameter, and at least
+   * `1`) so a zero-ish `leaderWidth`/`leaderHeight` can't collapse the SVG
+   * `width`/`viewBox` to an invalid `0`. The clamped `leaderWidth` is the single
+   * value used for the SVG width, the line endpoint AND the surface offset, so
+   * the line and label stay aligned — including when flipped.
+   */
+  export const resolveTileMapCalloutGeometry = (
+    leaderWidth: number,
+    leaderHeight: number,
+    dotRadius: number
+  ): TileMapCalloutGeometry => {
+    const clampedLeaderWidth = Math.max(leaderWidth, dotRadius * 2, 1);
+    const svgHeight = Math.max(leaderHeight + dotRadius * 2, 1);
+    return {
+      leaderWidth: clampedLeaderWidth,
+      svgHeight,
+      dotCx: dotRadius,
+      dotCxFlipped: clampedLeaderWidth - dotRadius,
+      dotCyAbove: svgHeight - dotRadius,
+      dotCyBelow: dotRadius,
+    };
+  };
 </script>
 
 <script lang="ts">
@@ -147,16 +187,19 @@ placement and lifecycle through the map context.
       DEFAULT_TILE_MAP_CALLOUT_DOT_RADIUS
     )
   );
-  let svgHeight = $derived(safeLeaderHeight + safeDotRadius * 2);
-  let dotCx = $derived(safeDotRadius);
-  let dotCxFlipped = $derived(safeLeaderWidth - safeDotRadius);
-  let dotCyAbove = $derived(svgHeight - safeDotRadius);
-  let dotCyBelow = $derived(safeDotRadius);
+  let geometry = $derived(
+    resolveTileMapCalloutGeometry(
+      safeLeaderWidth,
+      safeLeaderHeight,
+      safeDotRadius
+    )
+  );
   // Feed the same values to the CSS via custom properties on the callout root:
   // `--tile-map-callout-leader-width` sets the surface's inline offset and
-  // `--tile-map-callout-dot-radius` anchors the transform onto the dot.
+  // `--tile-map-callout-dot-radius` anchors the transform onto the dot. The
+  // offset uses the clamped `geometry.leaderWidth` so it matches the SVG.
   let calloutStyle = $derived(
-    `--tile-map-callout-leader-width: ${safeLeaderWidth}px; ` +
+    `--tile-map-callout-leader-width: ${geometry.leaderWidth}px; ` +
       `--tile-map-callout-dot-radius: ${safeDotRadius}px;`
   );
 
@@ -222,40 +265,40 @@ placement and lifecycle through the map context.
     </div>
     <div class="leader-line" aria-hidden="true">
       <svg
-        width={safeLeaderWidth}
-        height={svgHeight}
-        viewBox="0 0 {safeLeaderWidth} {svgHeight}"
+        width={geometry.leaderWidth}
+        height={geometry.svgHeight}
+        viewBox="0 0 {geometry.leaderWidth} {geometry.svgHeight}"
         focusable="false"
       >
         {#if isBelow}
           <line
-            x1={safeFlip ? dotCxFlipped : dotCx}
-            y1={dotCyBelow}
-            x2={safeFlip ? 0 : safeLeaderWidth}
-            y2={svgHeight}
+            x1={safeFlip ? geometry.dotCxFlipped : geometry.dotCx}
+            y1={geometry.dotCyBelow}
+            x2={safeFlip ? 0 : geometry.leaderWidth}
+            y2={geometry.svgHeight}
             stroke="currentColor"
             stroke-width="1"
             vector-effect="non-scaling-stroke"
           />
           <circle
-            cx={safeFlip ? dotCxFlipped : dotCx}
-            cy={dotCyBelow}
+            cx={safeFlip ? geometry.dotCxFlipped : geometry.dotCx}
+            cy={geometry.dotCyBelow}
             r={safeDotRadius}
             fill="currentColor"
           />
         {:else}
           <line
-            x1={safeFlip ? dotCxFlipped : dotCx}
-            y1={dotCyAbove}
-            x2={safeFlip ? 0 : safeLeaderWidth}
+            x1={safeFlip ? geometry.dotCxFlipped : geometry.dotCx}
+            y1={geometry.dotCyAbove}
+            x2={safeFlip ? 0 : geometry.leaderWidth}
             y2={0}
             stroke="currentColor"
             stroke-width="1"
             vector-effect="non-scaling-stroke"
           />
           <circle
-            cx={safeFlip ? dotCxFlipped : dotCx}
-            cy={dotCyAbove}
+            cx={safeFlip ? geometry.dotCxFlipped : geometry.dotCx}
+            cy={geometry.dotCyAbove}
             r={safeDotRadius}
             fill="currentColor"
           />

--- a/src/components/TileMapCallout/TileMapCallout.test.ts
+++ b/src/components/TileMapCallout/TileMapCallout.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'svelte/server';
 import TileMapCallout, {
+  DEFAULT_TILE_MAP_CALLOUT_DOT_RADIUS,
+  DEFAULT_TILE_MAP_CALLOUT_LEADER_HEIGHT,
+  DEFAULT_TILE_MAP_CALLOUT_LEADER_WIDTH,
   normalizeTileMapCalloutCoordinates,
+  normalizeTileMapCalloutDimension,
   normalizeTileMapCalloutFlip,
   normalizeTileMapCalloutPlacement,
 } from './TileMapCallout.svelte';
@@ -42,6 +46,24 @@ describe('TileMapCallout helpers', () => {
     expect(normalizeTileMapCalloutCoordinates([Number.NaN, 40])).toBeNull();
     expect(normalizeTileMapCalloutCoordinates({ lng: -73.9 })).toBeNull();
     expect(normalizeTileMapCalloutCoordinates('Times Square')).toBeNull();
+  });
+
+  it('defaults the leader geometry to the local-callout values', () => {
+    expect(DEFAULT_TILE_MAP_CALLOUT_LEADER_WIDTH).toBe(14);
+    expect(DEFAULT_TILE_MAP_CALLOUT_LEADER_HEIGHT).toBe(14);
+    expect(DEFAULT_TILE_MAP_CALLOUT_DOT_RADIUS).toBe(3);
+  });
+
+  it('normalizes geometry dimensions to a non-negative finite number', () => {
+    expect(normalizeTileMapCalloutDimension(20, 14)).toBe(20);
+    expect(normalizeTileMapCalloutDimension(0, 14)).toBe(0);
+    expect(normalizeTileMapCalloutDimension(-5, 14)).toBe(14);
+    expect(normalizeTileMapCalloutDimension(Number.NaN, 14)).toBe(14);
+    expect(normalizeTileMapCalloutDimension(Number.POSITIVE_INFINITY, 14)).toBe(
+      14
+    );
+    expect(normalizeTileMapCalloutDimension('32', 14)).toBe(14);
+    expect(normalizeTileMapCalloutDimension(undefined, 3)).toBe(3);
   });
 });
 

--- a/src/components/TileMapCallout/TileMapCallout.test.ts
+++ b/src/components/TileMapCallout/TileMapCallout.test.ts
@@ -8,6 +8,7 @@ import TileMapCallout, {
   normalizeTileMapCalloutDimension,
   normalizeTileMapCalloutFlip,
   normalizeTileMapCalloutPlacement,
+  resolveTileMapCalloutGeometry,
 } from './TileMapCallout.svelte';
 
 describe('TileMapCallout helpers', () => {
@@ -64,6 +65,39 @@ describe('TileMapCallout helpers', () => {
     );
     expect(normalizeTileMapCalloutDimension('32', 14)).toBe(14);
     expect(normalizeTileMapCalloutDimension(undefined, 3)).toBe(3);
+  });
+
+  it('resolves the default leader geometry', () => {
+    const geometry = resolveTileMapCalloutGeometry(14, 14, 3);
+    expect(geometry).toEqual({
+      leaderWidth: 14,
+      svgHeight: 20,
+      dotCx: 3,
+      dotCxFlipped: 11,
+      dotCyAbove: 17,
+      dotCyBelow: 3,
+    });
+  });
+
+  it('keeps the SVG canvas valid when dimensions collapse to zero', () => {
+    // A zero leaderWidth must not produce a 0-width SVG/viewBox: clamp to at
+    // least the dot diameter so the dot still renders, and the surface offset
+    // (which reuses leaderWidth) stays aligned with the line.
+    const withDot = resolveTileMapCalloutGeometry(0, 0, 3);
+    expect(withDot.leaderWidth).toBe(6);
+    expect(withDot.svgHeight).toBe(6);
+
+    // Everything zero still yields a positive 1px canvas rather than 0.
+    const degenerate = resolveTileMapCalloutGeometry(0, 0, 0);
+    expect(degenerate.leaderWidth).toBe(1);
+    expect(degenerate.svgHeight).toBe(1);
+  });
+
+  it('does not shrink an explicitly large leader below its requested size', () => {
+    const geometry = resolveTileMapCalloutGeometry(40, 32, 5);
+    expect(geometry.leaderWidth).toBe(40);
+    expect(geometry.svgHeight).toBe(42);
+    expect(geometry.dotCxFlipped).toBe(35);
   });
 });
 


### PR DESCRIPTION
## What

The `TileMapCallout` added in #460 (v4.5.0) shipped a longer leader line than the callout it replaced downstream. Its geometry was also duplicated across hardcoded JS constants (`lineWidth = 32`, `lineHeight = 28`, `dotRadius = 4`) **and** CSS custom-property defaults, which could drift apart and left no clean way to override the drawn line (only the surface offset var was exposed).

## Changes

- **Restore the compact default**: the leader now defaults to a **14×14px** line with a **3px** dot — matching the original local callout it replaced — instead of 32×28px / 4px.
- **Make it configurable**: new `leaderWidth`, `leaderHeight` and `dotRadius` props (all px).
- **Single source of truth**: the SVG geometry and the surface's offset/transform are both derived from those props (applied as inline `--tile-map-callout-*` custom properties), so they can no longer drift. Colour/shadow/max-width CSS vars remain the theming API.
- Added a `normalizeTileMapCalloutDimension` helper (coerces to a non-negative finite number) with unit tests, a 'Custom leader geometry' story, and docs.

## Testing

- `pnpm exec vitest run` — 245/245 pass (7 in TileMapCallout, incl. new default + normalizer tests)
- `pnpm run check` — 0 errors
- `pnpm lint` / `pnpm format` — clean

Changeset: `minor` (adds props + changes a just-released default).

cc an editor for review.