### PR TITLE
fix(TileMapCallout): compact, configurable leader line (clean of #464 autofix commits)

### DIFF
--- a/.changeset/fix-tile-map-callout-props.md
+++ b/.changeset/fix-tile-map-callout-props.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+`TileMapCallout`: repair the `Props` interface and component doc comment that automated review-suggestion commits had mangled in #464 (the `leaderWidth` prop declaration was dropped, leaving a dangling JSDoc block that broke `svelte-check` and lint). Restores the correct, formatted source; no runtime behaviour change from the intended #464 feature.

--- a/src/components/TileMapCallout/TileMapCallout.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.svelte
@@ -1,7 +1,8 @@
-<!--
-  @component A positioned annotation marker for a longitude/latitude point on a TileMap. Used inside TileMap.
+<!-- @component `TileMapCallout` [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-graphics-tilemapcallout--docs)
 
-  [Read the docs.](https://reuters-graphics.github.io/graphics-components/?path=/docs/components-graphics-tilemapcallout--docs)
+A MapLibre-aware callout for `TileMap`. Render it as a child of any
+`TileMap`, pass a longitude/latitude pair, and the component manages marker
+placement and lifecycle through the map context.
 -->
 <script lang="ts" module>
   export type TileMapCalloutPlacement = 'above' | 'below';
@@ -132,13 +133,14 @@
     class?: string;
     /** Add an id to the MapLibre marker wrapper. */
     id?: string;
-/**
- * Leader-line width in px — horizontal distance from the dot edge to the callout
- * surface. Values are normalized to non-negative finite numbers; when the
- * requested width would collapse the SVG (e.g. `0`), it is clamped to at least
- * the dot diameter (and at least `1px`) so the dot/offset stay aligned.
- * Defaults to `14`.
- */
+    /**
+     * Leader-line width in px — the horizontal distance from the marker dot to
+     * the callout surface. Also sets the surface's offset from the dot so the
+     * line and surface always line up. Clamped to at least the dot diameter
+     * (and at least `1px`) so a `0`-ish value can't collapse the SVG. Defaults
+     * to `14`.
+     */
+    leaderWidth?: number;
     /**
      * Leader-line height in px — the vertical distance the diagonal rises
      * (`placement="above"`) or drops (`placement="below"`). Defaults to `14`.


### PR DESCRIPTION
Supersedes #464.

#464's branch was polluted by two automated "Potential fix for pull request finding" commits that mangled the `Props` interface — they deleted the `leaderWidth?: number;` declaration and left a dangling JSDoc block — which broke `svelte-check` and `lint`. This branch is the clean, reviewed state without those commits.

## What

`TileMapCallout` (added in #460, v4.5.0) shipped a longer leader than the callout it replaced downstream, with geometry duplicated across hardcoded JS constants and CSS defaults.

## Changes

- **Restore the compact default**: 14×14px leader with a 3px dot (was 32×28px / 4px).
- **Make it configurable**: new `leaderWidth`, `leaderHeight`, `dotRadius` props (px).
- **Single source of truth**: a pure `resolveTileMapCalloutGeometry()` helper derives the SVG geometry and the surface offset from the props so they can't drift, and clamps the canvas to `Math.max(leaderWidth, dotRadius * 2, 1)` — this keeps the `viewBox`/`width` positive and `dotCxFlipped` non-negative even for `0`-ish inputs (both Copilot review findings from #464).
- `normalizeTileMapCalloutDimension` helper, unit tests (incl. the zero-collapse edge cases), a 'Custom leader geometry' story, docs, and a `minor` changeset.

## Testing

- `pnpm exec vitest run` — all pass (10 TileMapCallout, incl. geometry-clamp tests)
- `pnpm run check` — 0 errors
- `pnpm lint` / `pnpm format` — clean

cc an editor for review.