### PR TITLE
feat(TileMapCallout): add surface="bare" prop + purge-safe surface theming

### DIFF
--- a/.changeset/tile-map-callout-bare-surface.md
+++ b/.changeset/tile-map-callout-bare-surface.md
@@ -1,0 +1,8 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+`TileMapCallout`: add a `surface="bare"` prop and make surface theming purge-safe.
+
+- New `surface` prop: `"filled"` (default) keeps the themed box; `"bare"` removes the background, border, shadow and padding so you can render your own pre-styled container inside the callout (the marker, leader line and positioning still apply).
+- The surface theming custom properties (`--tile-map-callout-surface-background`, `--tile-map-callout-border-colour`, `--tile-map-callout-shadow`, `--tile-map-callout-colour`, `--tile-map-callout-surface-max-width`) are now consumed with inline fallbacks and are no longer declared on the element. Consumers can override them from their own wrapper class and have the value cascade in — no specificity fight, and no need to target the internal `.callout-surface`, which downstream CSS purging (e.g. PurgeCSS) can strip. Default rendering is unchanged.

--- a/src/components/TileMapCallout/TileMapCallout.stories.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.stories.svelte
@@ -36,6 +36,12 @@
         control: { type: 'number', min: 0 },
         description: 'Marker dot radius in px.',
       },
+      surface: {
+        control: 'select',
+        options: ['filled', 'bare'],
+        description:
+          'Surface chrome: "filled" draws the themed box; "bare" removes it so you can render your own container.',
+      },
     },
   });
 </script>
@@ -128,6 +134,25 @@
   </TileMap>
 </Story>
 
+<Story asChild name="Bare surface" tags={['!autodocs', '!dev']}>
+  <TileMap
+    id="tile-map-callout-bare-demo"
+    center={[-73.9868, 40.7567]}
+    zoom={13}
+    interactive={true}
+    title="Bare surface"
+    description="With surface='bare' the callout draws no box — render your own pre-styled container inside. The marker, leader line and positioning still apply."
+    height="500px"
+  >
+    <TileMapCallout lngLat={[-73.9868, 40.7567]} surface="bare">
+      <div class="bare-card">
+        <strong>Times Square</strong>
+        <span>Bring your own box</span>
+      </div>
+    </TileMapCallout>
+  </TileMap>
+</Story>
+
 <style lang="scss">
   .rich-callout {
     display: grid;
@@ -142,5 +167,25 @@
   .rich-callout span {
     color: var(--theme-colour-text-secondary);
     font-size: 0.85em;
+  }
+
+  .bare-card {
+    display: grid;
+    gap: 0.125rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--theme-colour-brand-primary, #0078d1);
+    color: #fff;
+    border-radius: 0.5rem;
+    box-shadow: 0 0.25rem 0.75rem rgb(0 0 0 / 20%);
+    font-weight: 400;
+  }
+
+  .bare-card strong {
+    font-weight: 700;
+  }
+
+  .bare-card span {
+    font-size: 0.85em;
+    opacity: 0.85;
   }
 </style>

--- a/src/components/TileMapCallout/TileMapCallout.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.svelte
@@ -36,6 +36,24 @@ placement and lifecycle through the map context.
     return fallback;
   };
 
+  export type TileMapCalloutSurface = 'filled' | 'bare';
+
+  const VALID_SURFACES = new Set<TileMapCalloutSurface>(['filled', 'bare']);
+
+  export const normalizeTileMapCalloutSurface = (
+    value: unknown,
+    fallback: TileMapCalloutSurface = 'filled'
+  ): TileMapCalloutSurface => {
+    if (typeof value !== 'string') return fallback;
+
+    const normalized = value.trim().toLowerCase();
+    if (VALID_SURFACES.has(normalized as TileMapCalloutSurface)) {
+      return normalized as TileMapCalloutSurface;
+    }
+
+    return fallback;
+  };
+
   const isFiniteNumber = (value: unknown): value is number =>
     typeof value === 'number' && Number.isFinite(value);
 
@@ -148,6 +166,13 @@ placement and lifecycle through the map context.
     leaderHeight?: number;
     /** Marker dot radius in px. Defaults to `3`. */
     dotRadius?: number;
+    /**
+     * Surface chrome. `"filled"` (default) draws the themed box (background,
+     * border and shadow). `"bare"` removes that chrome so you can render your
+     * own container inside the callout — the marker, leader line and
+     * positioning still apply. Useful when wrapping a pre-styled card.
+     */
+    surface?: TileMapCalloutSurface;
   }
 
   let {
@@ -160,6 +185,7 @@ placement and lifecycle through the map context.
     leaderWidth = DEFAULT_TILE_MAP_CALLOUT_LEADER_WIDTH,
     leaderHeight = DEFAULT_TILE_MAP_CALLOUT_LEADER_HEIGHT,
     dotRadius = DEFAULT_TILE_MAP_CALLOUT_DOT_RADIUS,
+    surface = 'filled',
   }: Props = $props();
 
   const mapStore = getContext<Writable<MaplibreMap | null>>('map');
@@ -211,6 +237,7 @@ placement and lifecycle through the map context.
   let safeLngLat = $derived(normalizeTileMapCalloutCoordinates(lngLat));
   let safeFlip = $derived(normalizeTileMapCalloutFlip(flip));
   let safePlacement = $derived(normalizeTileMapCalloutPlacement(placement));
+  let safeSurface = $derived(normalizeTileMapCalloutSurface(surface));
   let isBelow = $derived(safePlacement === 'below');
   let calloutClasses = $derived(
     ['tile-map-callout', `placement-${safePlacement}`, safeFlip && 'flip', cls]
@@ -260,7 +287,7 @@ placement and lifecycle through the map context.
   data-has-coordinates={safeLngLat ? 'true' : 'false'}
 >
   <div class={calloutClasses} style={calloutStyle}>
-    <div class="callout-surface">
+    <div class="callout-surface" class:surface-bare={safeSurface === 'bare'}>
       {#if children}
         {@render children()}
       {/if}
@@ -323,20 +350,25 @@ placement and lifecycle through the map context.
   }
 
   .tile-map-callout {
-    /* `--tile-map-callout-leader-width` and `--tile-map-callout-dot-radius`
-       are set inline from the `leaderWidth`/`dotRadius` props (see the script)
-       so geometry has a single source of truth; the values here are the
-       matching fallbacks. Colour/shadow/max-width vars remain the theming API. */
+    /* Geometry vars (`--tile-map-callout-leader-width` /
+       `--tile-map-callout-dot-radius`) are set inline from the
+       leaderWidth/dotRadius props (see the script) so the drawn line and the
+       surface offset share one source of truth; the values here are the
+       matching fallbacks — don't override them via CSS, use the props.
+
+       The theming vars (surface background/border/shadow/colour/max-width) are
+       deliberately NOT declared on the element: they're consumed below with
+       inline fallbacks. That lets a consumer set any of them on their OWN
+       wrapper class and have it cascade in — no specificity fight, and no need
+       to target the internal `.callout-surface` (which downstream CSS purging
+       can strip). Prefer `surface="bare"` when you just want to drop the box. */
     --tile-map-callout-dot-radius: 3px;
     --tile-map-callout-leader-width: 14px;
-    --tile-map-callout-surface-max-width: min(14rem, calc(100vw - 2rem));
-    --tile-map-callout-surface-background: var(--theme-colour-background, #fff);
-    --tile-map-callout-colour: var(--theme-colour-text-primary, #404040);
-    --tile-map-callout-border-colour: var(--theme-colour-text-primary, #404040);
-    --tile-map-callout-shadow: 0 0.125rem 0.5rem
-      var(--theme-colour-brand-shadow, rgb(64 64 64 / 8%));
 
-    color: var(--tile-map-callout-colour);
+    color: var(
+      --tile-map-callout-colour,
+      var(--theme-colour-text-primary, #404040)
+    );
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -344,7 +376,10 @@ placement and lifecycle through the map context.
     position: absolute;
     left: 0;
     top: 0;
-    max-width: var(--tile-map-callout-surface-max-width);
+    max-width: var(
+      --tile-map-callout-surface-max-width,
+      min(14rem, calc(100vw - 2rem))
+    );
     box-sizing: border-box;
     transform: translate(
       calc(-1 * var(--tile-map-callout-dot-radius)),
@@ -380,17 +415,41 @@ placement and lifecycle through the map context.
     margin-block-end: -1px;
     margin-inline-start: var(--tile-map-callout-leader-width);
     width: max-content;
-    max-width: var(--tile-map-callout-surface-max-width);
+    max-width: var(
+      --tile-map-callout-surface-max-width,
+      min(14rem, calc(100vw - 2rem))
+    );
     box-sizing: border-box;
-    background: var(--tile-map-callout-surface-background);
-    border: 1px solid var(--tile-map-callout-border-colour);
-    box-shadow: var(--tile-map-callout-shadow);
+    background: var(
+      --tile-map-callout-surface-background,
+      var(--theme-colour-background, #fff)
+    );
+    border: 1px solid
+      var(
+        --tile-map-callout-border-colour,
+        var(--theme-colour-text-primary, #404040)
+      );
+    box-shadow: var(
+      --tile-map-callout-shadow,
+      0 0.125rem 0.5rem var(--theme-colour-brand-shadow, rgb(64 64 64 / 8%))
+    );
     padding: 0.375rem 0.625rem;
     font-family: var(--theme-font-family-note, Knowledge, sans-serif);
     font-size: var(--theme-font-size-xs, 0.875rem);
     font-weight: 700;
     line-height: 1.25;
     overflow-wrap: anywhere;
+  }
+
+  /* `surface="bare"`: strip the box so a consumer can render their own
+     container inside the callout. Authored here (in the library) so it ships in
+     the component's own CSS and isn't a consumer-side override that purging
+     could remove. */
+  .callout-surface.surface-bare {
+    background: none;
+    border: 0;
+    box-shadow: none;
+    padding: 0;
   }
 
   .tile-map-callout.flip .callout-surface {

--- a/src/components/TileMapCallout/TileMapCallout.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.svelte
@@ -38,20 +38,18 @@ placement and lifecycle through the map context.
 
   export type TileMapCalloutSurface = 'filled' | 'bare';
 
-  const VALID_SURFACES = new Set<TileMapCalloutSurface>(['filled', 'bare']);
-
   export const normalizeTileMapCalloutSurface = (
     value: unknown,
     fallback: TileMapCalloutSurface = 'filled'
   ): TileMapCalloutSurface => {
     if (typeof value !== 'string') return fallback;
 
+    // The literal comparison narrows `normalized` to `TileMapCalloutSurface`
+    // in the truthy branch, so this stays fully type-safe with no assertions.
     const normalized = value.trim().toLowerCase();
-    if (VALID_SURFACES.has(normalized as TileMapCalloutSurface)) {
-      return normalized as TileMapCalloutSurface;
-    }
-
-    return fallback;
+    return normalized === 'filled' || normalized === 'bare'
+      ? normalized
+      : fallback;
   };
 
   const isFiniteNumber = (value: unknown): value is number =>

--- a/src/components/TileMapCallout/TileMapCallout.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.svelte
@@ -47,8 +47,8 @@ placement and lifecycle through the map context.
     // The literal comparison narrows `normalized` to `TileMapCalloutSurface`
     // in the truthy branch, so this stays fully type-safe with no assertions.
     const normalized = value.trim().toLowerCase();
-    return normalized === 'filled' || normalized === 'bare'
-      ? normalized
+    return normalized === 'filled' || normalized === 'bare' ?
+        normalized
       : fallback;
   };
 

--- a/src/components/TileMapCallout/TileMapCallout.test.ts
+++ b/src/components/TileMapCallout/TileMapCallout.test.ts
@@ -8,6 +8,7 @@ import TileMapCallout, {
   normalizeTileMapCalloutDimension,
   normalizeTileMapCalloutFlip,
   normalizeTileMapCalloutPlacement,
+  normalizeTileMapCalloutSurface,
   resolveTileMapCalloutGeometry,
 } from './TileMapCallout.svelte';
 
@@ -23,6 +24,15 @@ describe('TileMapCallout helpers', () => {
     expect(normalizeTileMapCalloutFlip(true)).toBe(true);
     expect(normalizeTileMapCalloutFlip(false)).toBe(false);
     expect(normalizeTileMapCalloutFlip('true')).toBe(false);
+  });
+
+  it('normalizes surface values', () => {
+    expect(normalizeTileMapCalloutSurface('bare')).toBe('bare');
+    expect(normalizeTileMapCalloutSurface('filled')).toBe('filled');
+    expect(normalizeTileMapCalloutSurface(' BARE ')).toBe('bare');
+    expect(normalizeTileMapCalloutSurface('glass')).toBe('filled');
+    expect(normalizeTileMapCalloutSurface(undefined)).toBe('filled');
+    expect(normalizeTileMapCalloutSurface(null)).toBe('filled');
   });
 
   it('accepts common longitude/latitude shapes', () => {

--- a/src/components/TileMapCallout/TileMapCallout.test.ts
+++ b/src/components/TileMapCallout/TileMapCallout.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import type { ComponentProps } from 'svelte';
 import { render } from 'svelte/server';
+import { writable } from 'svelte/store';
 import TileMapCallout, {
   DEFAULT_TILE_MAP_CALLOUT_DOT_RADIUS,
   DEFAULT_TILE_MAP_CALLOUT_LEADER_HEIGHT,
@@ -112,6 +114,15 @@ describe('TileMapCallout helpers', () => {
 });
 
 describe('TileMapCallout component', () => {
+  // Render on the server with a mock `map` context so the component doesn't
+  // throw. The marker `$effect` (which needs MapLibre) is client-only and
+  // doesn't run during SSR, so the rendered markup reflects the props alone.
+  const renderWithMap = (props: ComponentProps<typeof TileMapCallout>) =>
+    render(TileMapCallout, {
+      props,
+      context: new Map([['map', writable(null)]]),
+    });
+
   it('requires TileMap context', () => {
     expect(() => {
       const result = render(TileMapCallout, {
@@ -119,5 +130,19 @@ describe('TileMapCallout component', () => {
       });
       expect(result.body).toBeDefined();
     }).toThrow('TileMapCallout must be used inside a TileMap component');
+  });
+
+  it('applies the surface-bare class when surface="bare"', () => {
+    const { body } = renderWithMap({
+      lngLat: [-73.9868, 40.7567],
+      surface: 'bare',
+    });
+    expect(body).toContain('surface-bare');
+  });
+
+  it('omits the surface-bare class for the default filled surface', () => {
+    const { body } = renderWithMap({ lngLat: [-73.9868, 40.7567] });
+    expect(body).toContain('callout-surface');
+    expect(body).not.toContain('surface-bare');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,7 @@ export type {
 export type {
   TileMapCalloutCoordinates,
   TileMapCalloutPlacement,
+  TileMapCalloutSurface,
 } from './components/TileMapCallout/TileMapCallout.svelte';
 
 export type {


### PR DESCRIPTION
## Why

Consuming projects that wrap `TileMapCallout` around their own styled card hit two related problems:

1. **No clean way to drop the library's surface box.** The `.callout-surface` renders a themed white box (background + border + shadow). To wrap a pre-styled card, consumers had to *override* that chrome by targeting the internal `.callout-surface` class.
2. **Those overrides get purged in production.** `.callout-surface` / `.tile-map-callout` / `.leader-line` are only emitted at runtime, so a consumer's PurgeCSS pass treats overrides targeting them as unused and strips them from the build — but not in dev. This produced a **"double box" callout on built pages but not on the dev server** in reuters-climate-monitor (fixed downstream with a purge safelist in that repo's PR #221; this PR fixes the root cause here).

## What

- **New `surface` prop.** `"filled"` (default) keeps the themed box; `"bare"` removes background/border/shadow/padding so you can render your own container inside the callout — the marker, leader line and positioning still apply. Because the `.callout-surface.surface-bare` rule ships in the library's own CSS, it's not a consumer-side override that purging can remove.
- **Purge-safe theming.** The surface theming custom properties (`--tile-map-callout-surface-background`, `--tile-map-callout-border-colour`, `--tile-map-callout-shadow`, `--tile-map-callout-colour`, `--tile-map-callout-surface-max-width`) are now **consumed with inline fallbacks** and no longer declared on the element. A consumer can set any of them on **their own wrapper class** and it cascades in — no specificity fight, and no need to target internal classes. Default rendering is unchanged.

## API

```svelte
<!-- Bring your own box -->
<TileMapCallout lngLat={[lng, lat]} surface="bare">
  <MyCard … />
</TileMapCallout>

<!-- Or theme the default box from your own wrapper (purge-safe) -->
<TileMapCallout class="my-callout" lngLat={[lng, lat]}>…</TileMapCallout>
<style>
  :global(.my-callout) { --tile-map-callout-surface-background: transparent; }
</style>
```

## Tests / gates

- New `normalizeTileMapCalloutSurface` + unit tests (11 pass).
- `pnpm run check` — 0 errors.
- `pnpm run build` — packages clean; publint "All good!".
- New "Bare surface" Storybook story + `surface` argType.
- Adds a `minor` changeset.

## Notes

Default (`surface="filled"`) output is byte-identical — the theming vars resolve to the same values via their inline fallbacks. Motivated by reuters-climate-monitor's `ClimateMapCallout` (wraps a `DataCardBase`); it can drop its manual `.callout-surface` override + purge safelist once this ships and adopt `surface="bare"`.

cc an editor for review.