### PR TITLE
fix(BeforeAfter): avoid new DOMRect() so SSR doesn't throw

### DIFF
--- a/.changeset/before-after-ssr-domrect.md
+++ b/.changeset/before-after-ssr-domrect.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+`BeforeAfter`: fix `ReferenceError: DOMRect is not defined` on SSR. The `imgOffset` state initializer called `new DOMRect()`, a browser-only API that also runs during server rendering; it now initializes with a plain object literal instead. Fixes #453.

--- a/src/components/BeforeAfter/BeforeAfter.svelte
+++ b/src/components/BeforeAfter/BeforeAfter.svelte
@@ -94,8 +94,11 @@
    */
   let img: HTMLImageElement | undefined = $state(undefined);
 
-  /** Defaults with an empty DOMRect with all values set to 0 */
-  let imgOffset: DOMRect = $state(new DOMRect());
+  /** Defaults with a rect-like object with all values set to 0. Avoids `new DOMRect()`, which doesn't exist during SSR. */
+  let imgOffset: Pick<DOMRect, 'width' | 'left'> = $state({
+    width: 0,
+    left: 0,
+  });
   let sliding = false;
   let figure: HTMLElement | undefined = $state(undefined);
   let beforeOverlayWidth = $state(0);

--- a/src/components/BeforeAfter/BeforeAfter.test.ts
+++ b/src/components/BeforeAfter/BeforeAfter.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import BeforeAfter from './BeforeAfter.svelte';
+
+describe('BeforeAfter', () => {
+  it('renders during SSR without throwing on the DOMRect-initialized offset state', () => {
+    // `imgOffset` used to initialize with `new DOMRect()`, which doesn't exist
+    // in Node and threw on any SSR render of this component.
+    const { body } = render(BeforeAfter, {
+      props: {
+        beforeSrc: '/before.jpg',
+        beforeAlt: 'Before',
+        afterSrc: '/after.jpg',
+        afterAlt: 'After',
+      },
+    });
+
+    expect(body).toContain('before-after-container');
+  });
+});


### PR DESCRIPTION
## Summary
- `imgOffset`'s `$state` initializer called `new DOMRect()`, a browser-only API that also runs during server rendering, causing `ReferenceError: DOMRect is not defined` on any SSR render of `<BeforeAfter>`.
- Initializes `imgOffset` with a plain object literal instead, typed to just the `width`/`left` fields the component actually reads.
- Adds an SSR render regression test (`svelte/server`'s `render`, matching the pattern used by `TileMapCallout`/`ArcCluster`) that reproduces the original error on the old code and passes with the fix.
- Adds a patch changeset.

Fixes #453

## Test plan
- [x] `npx vitest run` — 152 passed
- [x] Confirmed the new test fails with the original `new DOMRect()` code and passes with the fix
- [x] `npx eslint src/components/BeforeAfter/` — clean
- [x] `npx prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)