### PR TITLE
ci: run vitest on pull requests to main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,11 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    uses: reuters-graphics/action-workflows/.github/workflows/test.yaml@main
+    secrets: inherit

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "changeset:version": "changeset version",
     "changeset:publish": "git add --all && changeset publish",
     "knip": "knip",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "license": "MIT",
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,17 @@
 import { defineConfig, type UserConfig } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { configDefaults } from 'vitest/config';
 
 const config: UserConfig = defineConfig({
   css: {
     preprocessorOptions: { scss: { quietDeps: true } },
   },
   plugins: [sveltekit()],
+  test: {
+    // Vitest v4's default exclude no longer covers `dist/`, so a built
+    // package would otherwise re-run every test against its compiled copy.
+    exclude: [...configDefaults.exclude, 'dist/**', '.svelte-kit/**'],
+  },
 });
 
 export default config;


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yaml`, using this org's shared `action-workflows` reusable test workflow (same pattern as `lint.yaml`/`docs.yaml`/`release.yaml`), so the vitest suite actually runs on PRs to `main`. Previously `check.yaml` (svelte-check), `lint.yaml` (eslint/prettier), and `chromatic.yaml` ran, but nothing ran `pnpm test`.
- The shared workflow builds the package before testing. That surfaced a latent bug: Vitest v4 trimmed its default `exclude` list down to just `node_modules`/`.git` (older versions also excluded `dist`), so once `dist/` exists, every test file's compiled copy under `dist/` (and the intermediate `.svelte-kit/__package__/`) gets collected and run a second and third time. Added explicit `exclude` entries in `vite.config.ts` for both.
- Switched `"test"` to `"vitest run"` so it doesn't rely on implicit CI-detection to skip watch mode, and added `"test:watch"` for local development.

No changeset — this is CI/tooling only and doesn't change the published package's runtime behavior, matching prior CI-only commits in this repo's history.

## Test plan
- [x] `pnpm build && pnpm test` — 15 test files / 104 tests, no duplicates from `dist`/`.svelte-kit`
- [x] `pnpm test` with no prior build — same 15/104, confirming the exclude doesn't drop any real tests
- [x] `npx eslint .` / `npx prettier --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)