### PR TITLE
ci: publish docs as part of the release workflow run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ jobs:
     secrets: inherit
     with:
       node_version: '22'
+      publish_docs: true
 
   notify-downstream:
     needs: release


### PR DESCRIPTION
## Summary
- `docs.yaml` listens for `release: types: [published]`, but that GitHub Release is created by `changesets/action` using the default `GITHUB_TOKEN` — and GitHub deliberately suppresses events triggered by the default token from starting other workflow runs (recursion prevention). Confirmed via history: every past `docs.yaml` run was `workflow_dispatch`, none fired from a `release` event, despite non-draft releases (e.g. `v4.8.1`) being published successfully by `github-actions[bot]`.
- The shared `changesets-release.yaml` reusable workflow already has a `publish_docs` input (default `false`) that runs the docs-publish job inline, in the same workflow run, right after a successful `npm publish` — this sidesteps the cross-workflow trigger limitation entirely rather than fighting it.
- Sets `publish_docs: true` in `release.yaml`. Defaults for `docs_directory` (`./docs`) and `build_script` (`build`) already match this repo's `build:docs`/`build` scripts, so no other inputs are needed.
- Left the existing `release: published` trigger in `docs.yaml` as-is — it still covers a release a human creates manually through the GitHub UI (using their own token).

## Test plan
- [x] `npx prettier --check .github/workflows/release.yaml` — clean
- [x] Validated YAML parses correctly
- [ ] Confirm on the next changeset-triggered release that the docs job runs inline (job will appear as `release / docs` in the same workflow run, not a separate `docs.yaml` run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)