### PR TITLE
chore: add Chromatic ignore parameters for non-deterministic stories

### DIFF
--- a/src/components/ClockWall/ClockWall.stories.svelte
+++ b/src/components/ClockWall/ClockWall.stories.svelte
@@ -15,6 +15,11 @@
         options: ['Light', 'Normal', 'Bold'],
       },
     },
+    parameters: {
+      // Renders the live wall-clock time, redrawn every 10s, with no way to
+      // pin it externally — never visually stable, so skip Chromatic.
+      chromatic: { disable: true },
+    },
   });
 </script>
 

--- a/src/components/Lottie/Lottie.stories.svelte
+++ b/src/components/Lottie/Lottie.stories.svelte
@@ -35,6 +35,11 @@
         },
       },
     },
+    parameters: {
+      // Canvas-rendered autoplay animation — Chromatic can't pause canvas
+      // rendering the way it does CSS animations, so skip it.
+      chromatic: { disable: true },
+    },
   });
 
   let progress = $state(0);

--- a/src/components/ScrollerVideo/ScrollerVideo.stories.svelte
+++ b/src/components/ScrollerVideo/ScrollerVideo.stories.svelte
@@ -168,7 +168,16 @@
   <Embedded />
 </Story>
 
-<Story asChild name="Autoplay">
+<Story
+  asChild
+  name="Autoplay"
+  parameters={{
+    // Canvas-decoded frames advance on a timer while autoplaying — never
+    // pixel-stable, so skip Chromatic (unlike the scroll-driven stories,
+    // which render a fixed frame at the static scroll position).
+    chromatic: { disable: true },
+  }}
+>
   <ScrollerVideo {...args} src={videoSrc.Goldengate} autoplay={true} />
 </Story>
 

--- a/src/components/TileMap/TileMap.stories.svelte
+++ b/src/components/TileMap/TileMap.stories.svelte
@@ -151,6 +151,11 @@
         control: 'boolean',
       },
     },
+    parameters: {
+      // Renders live map tiles (and, in some stories, a live GeoJSON fetch
+      // or an embedded Geocoder) — never pixel-stable, so skip Chromatic.
+      chromatic: { disable: true },
+    },
   });
 </script>
 

--- a/src/components/TileMapCallout/TileMapCallout.stories.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.stories.svelte
@@ -43,6 +43,10 @@
           'Surface chrome: "filled" draws the themed box; "bare" removes it so you can render your own container.',
       },
     },
+    parameters: {
+      // Every story nests a live TileMap (live tile fetches) — skip Chromatic.
+      chromatic: { disable: true },
+    },
   });
 </script>
 


### PR DESCRIPTION
## Summary
- Several Storybook stories render live/non-deterministic content — live map tiles + a live GeoJSON fetch (`TileMap`, `TileMapCallout`), a real-time clock (`ClockWall`), and canvas-driven animation (`Lottie`, `ScrollerVideo`'s "Autoplay" story) — which trip Chromatic visual diffs on essentially every PR
- Added `parameters: { chromatic: { disable: true } }` to the affected story metas/stories, following this repo's existing ignore-mechanism precedents (`Article.stories.svelte`, `HorizontalScroller.stories.svelte`, `HeroHeadline.stories.svelte`, `Referral.svelte`, `DatawrapperChart.svelte`)
- `Video.stories.svelte` needed no change — Chromatic already auto-pauses native `<video>` elements at their first frame; only JS/canvas-driven rendering (Lottie, ScrollerVideo's WebCodecs decoding) needs manual handling
- `ScrollerVideo`'s other stories are purely scroll-position-driven and render a fixed, deterministic frame in Chromatic's static snapshot, so only the "Autoplay" story (which runs a timer-driven frame advance loop) needed the ignore flag, not the whole file

## Test plan
- [x] `pnpm lint` / prettier check on edited files — clean
- [x] `pnpm test` — 104/104 tests pass
- [x] `pnpm build:docs` — Storybook build completes successfully with the edited story files
- [ ] Confirm on this PR's Chromatic run that the disabled stories no longer appear as snapshot targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)