### PR TITLE
Split fuller blog example out of BlogTOC story into Compositions/Blog

### DIFF
--- a/src/components/BlogTOC/BlogTOC.stories.svelte
+++ b/src/components/BlogTOC/BlogTOC.stories.svelte
@@ -1,5 +1,6 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
+  import { expect, userEvent, within, waitFor } from 'storybook/test';
   import BlogTOC from './BlogTOC.svelte';
 
   const { Story } = defineMeta({
@@ -48,6 +49,36 @@
   ];
 </script>
 
-<Story name="Demo" asChild>
+<!--
+  BlogTOC is collapsed by default, so click it open — both to exercise the
+  interaction and so the Chromatic snapshot covers the expanded list, not
+  just the closed toggle button.
+-->
+<Story
+  name="Demo"
+  asChild
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: /show all articles/i });
+
+    await userEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(
+        canvas.getByText(
+          'Oil prices surge amid fears of wider Middle East conflict'
+        )
+      ).toBeVisible()
+    );
+  }}
+  parameters={{
+    // The list slides open on click; give it a beat to settle before
+    // Chromatic snapshots so it doesn't land mid-transition. The infinite
+    // scroll-hint animations inside the list carry their own
+    // data-chromatic="ignore" markers (see BlogTOC.svelte), since they never
+    // settle.
+    chromatic: { delay: 400 },
+  }}
+>
   <BlogTOC {posts} />
 </Story>

--- a/src/components/BlogTOC/BlogTOC.stories.svelte
+++ b/src/components/BlogTOC/BlogTOC.stories.svelte
@@ -1,10 +1,6 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import BlogTOC from './BlogTOC.svelte';
-  import BlogPost from '../BlogPost/BlogPost.svelte';
-  import BodyText from '../BodyText/BodyText.svelte';
-  import Headline from '../Headline/Headline.svelte';
-  import ClockWall from '../ClockWall/ClockWall.svelte';
 
   const { Story } = defineMeta({
     title: 'Components/Blog/BlogTOC',
@@ -53,36 +49,5 @@
 </script>
 
 <Story name="Demo" asChild>
-  <Headline
-    section="Graphics"
-    hed="Maps of the Iran crisis"
-    hedSize="big"
-    width="normal"
-    class="mb-2"
-  />
-
-  <ClockWall
-    cities={[
-      { name: 'Tehran', tzIdentifier: 'Asia/Tehran' },
-      { name: 'Tel Aviv', tzIdentifier: 'Asia/Tel_Aviv' },
-      { name: 'Washington D.C.', tzIdentifier: 'America/New_York' },
-    ]}
-  />
-
   <BlogTOC {posts} />
-
-  <BlogPost
-    title="Iran fires ballistic missiles at Israel in major escalation"
-    slugTitle="Iran fires ballistic missiles at Israel in major escalation"
-    authors={['John Smith', 'Jane Doe']}
-    publishTime="2024-10-01T18:30:00Z"
-    updateTime="2024-10-01T21:45:00Z"
-  >
-    <BodyText
-      text="Iran launched a barrage of ballistic missiles at Israel on Tuesday in its first direct attack on Israeli territory, marking a significant escalation in the conflict gripping the Middle East."
-    />
-    <BodyText
-      text="The attack, which Iran said was in retaliation for Israeli strikes that killed senior Hezbollah and Hamas leaders, prompted Israel and the United States to vow a response."
-    />
-  </BlogPost>
 </Story>

--- a/src/components/BlogTOC/BlogTOC.svelte
+++ b/src/components/BlogTOC/BlogTOC.svelte
@@ -117,13 +117,13 @@
                 <TOCList dates={contents} bind:listHeight />
 
                 {#if scrollPos > 10 && listHeight > maxHeight}
-                  <div class="scroll-icon up">
+                  <div class="scroll-icon up" data-chromatic="ignore">
                     <Fa icon={faAngleDoubleUp} />
                   </div>
                 {/if}
 
                 {#if listHeight > maxHeight && scrollPos < 0.95 * (listHeight - maxHeight)}
-                  <div class="scroll-icon down">
+                  <div class="scroll-icon down" data-chromatic="ignore">
                     <Fa icon={faAngleDoubleDown} />
                   </div>
                 {/if}

--- a/src/components/ScrollerVideo/Debug.svelte
+++ b/src/components/ScrollerVideo/Debug.svelte
@@ -42,9 +42,17 @@
 
 <svelte:window onmousemove={onMouseMove} />
 
+<!--
+  Masked from Chromatic: this console reports async video-decode state, none of
+  which is stable between snapshots. The source URL is rewritten to a
+  per-build `capture-loopback.chromatic.com` host, and the framerate/time rows
+  race the video's metadata load. It's developer diagnostics, not product UI,
+  so there's nothing worth diffing here.
+-->
 <div
   style="position: absolute; top: {position.y}px; left: {position.x}px; z-index: 5; user-select: none;"
   role="region"
+  data-chromatic="ignore"
 >
   <details class="debug-info" open>
     <summary

--- a/src/components/ScrollerVideo/ScrollerVideo.stories.svelte
+++ b/src/components/ScrollerVideo/ScrollerVideo.stories.svelte
@@ -117,6 +117,15 @@
         },
       },
     },
+    parameters: {
+      // Frames are decoded off the main thread and painted to a canvas, so an
+      // unhinted snapshot can land before the first frame exists — the canvas
+      // captures blank on one build and painted on the next. Chromatic waits
+      // for resources but can't see the decode, so hold the capture to give it
+      // room to finish. Note this reduces the race rather than removing it: a
+      // slow runner can still beat the delay.
+      chromatic: { delay: 8000 },
+    },
   });
 
   let width: number = $state(0);

--- a/src/compositions/Blog.mdx
+++ b/src/compositions/Blog.mdx
@@ -1,0 +1,11 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as BlogStories from './Blog.stories.svelte';
+
+<Meta of={BlogStories} />
+
+# Blog
+
+A live-news graphics blog page pairs a [`Headline`](?path=/docs/components-text-elements-headline--docs) with a [`ClockWall`](?path=/docs/components-blog-clockwall--docs) for the cities in the story, a [`BlogTOC`](?path=/docs/components-blog-blogtoc--docs) linking to every post published so far, and a series of [`BlogPost`](?path=/docs/components-blog-blogpost--docs) entries as the story develops.
+
+<Canvas of={BlogStories.Demo} />

--- a/src/compositions/Blog.stories.svelte
+++ b/src/compositions/Blog.stories.svelte
@@ -1,0 +1,121 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import { expect, within } from 'storybook/test';
+  import Headline from '../components/Headline/Headline.svelte';
+  import ClockWall from '../components/ClockWall/ClockWall.svelte';
+  import BlogTOC from '../components/BlogTOC/BlogTOC.svelte';
+  import BlogPost from '../components/BlogPost/BlogPost.svelte';
+  import BodyText from '../components/BodyText/BodyText.svelte';
+
+  // A live-news blog page pairs a Headline with a ClockWall for the cities in
+  // the story, a BlogTOC linking to every post published so far, and a series
+  // of BlogPost entries as the story develops.
+
+  const { Story } = defineMeta({
+    title: 'Compositions/Blog',
+    parameters: {
+      // This is a documentation-only composition, so hide the controls table.
+      controls: { disable: true },
+      // ClockWall redraws the real wall-clock time on a timer — there's no
+      // CSS animation to pause, so skip Chromatic entirely rather than try
+      // to pin it (matches ClockWall's own story, which does the same).
+      chromatic: { disable: true },
+    },
+  });
+
+  // Smoke-test the composed page: a `play` function turns this story into an
+  // interaction test that fails if any composed component stops rendering
+  // its key furniture.
+  async function smokeTest({ canvasElement }: { canvasElement: HTMLElement }) {
+    const canvas = within(canvasElement);
+    // The headline opens the page.
+    await expect(
+      canvas.getByText('Maps of the Iran crisis')
+    ).toBeInTheDocument();
+    // ClockWall renders a clock for each city.
+    await expect(canvas.getByText('Tehran')).toBeInTheDocument();
+    // BlogTOC renders its toggle button.
+    await expect(canvas.getByText('Show all articles')).toBeInTheDocument();
+    // The first BlogPost renders its body text.
+    await expect(
+      canvas.getByText(
+        'Iran launched a barrage of ballistic missiles at Israel on Tuesday in its first direct attack on Israeli territory, marking a significant escalation in the conflict gripping the Middle East.'
+      )
+    ).toBeInTheDocument();
+  }
+
+  const posts = [
+    {
+      title: 'Iran fires ballistic missiles at Israel in major escalation',
+      slugTitle: 'Iran fires ballistic missiles at Israel in major escalation',
+      publishTime: '2024-10-01T18:30:00Z',
+    },
+    {
+      title: 'Israel vows response as world leaders call for restraint',
+      slugTitle: 'Israel vows response as world leaders call for restraint',
+      publishTime: '2024-10-02T09:15:00Z',
+    },
+    {
+      title: 'Oil prices surge amid fears of wider Middle East conflict',
+      slugTitle: 'Oil prices surge amid fears of wider Middle East conflict',
+      publishTime: '2024-10-02T14:00:00Z',
+    },
+    {
+      title:
+        'UN Security Council holds emergency session on Iran-Israel crisis',
+      slugTitle:
+        'UN Security Council holds emergency session on Iran-Israel crisis',
+      publishTime: '2024-10-03T11:00:00Z',
+    },
+    {
+      title: 'Iran says missile attack achieved its objectives',
+      slugTitle: 'Iran says missile attack achieved its objectives',
+      publishTime: '2024-10-03T16:30:00Z',
+    },
+    {
+      title: 'Israel launches airstrikes on Hezbollah targets in Lebanon',
+      slugTitle: 'Israel launches airstrikes on Hezbollah targets in Lebanon',
+      publishTime: '2024-10-04T08:00:00Z',
+    },
+    {
+      title: 'U.S. sends additional warships to Middle East region',
+      slugTitle: 'U.S. sends additional warships to Middle East region',
+      publishTime: '2024-10-04T13:45:00Z',
+    },
+  ];
+</script>
+
+<Story name="Demo" asChild play={smokeTest}>
+  <Headline
+    section="Graphics"
+    hed="Maps of the Iran crisis"
+    hedSize="big"
+    width="normal"
+    class="mb-2"
+  />
+
+  <ClockWall
+    cities={[
+      { name: 'Tehran', tzIdentifier: 'Asia/Tehran' },
+      { name: 'Tel Aviv', tzIdentifier: 'Asia/Tel_Aviv' },
+      { name: 'Washington D.C.', tzIdentifier: 'America/New_York' },
+    ]}
+  />
+
+  <BlogTOC {posts} />
+
+  <BlogPost
+    title="Iran fires ballistic missiles at Israel in major escalation"
+    slugTitle="Iran fires ballistic missiles at Israel in major escalation"
+    authors={['John Smith', 'Jane Doe']}
+    publishTime="2024-10-01T18:30:00Z"
+    updateTime="2024-10-01T21:45:00Z"
+  >
+    <BodyText
+      text="Iran launched a barrage of ballistic missiles at Israel on Tuesday in its first direct attack on Israeli territory, marking a significant escalation in the conflict gripping the Middle East."
+    />
+    <BodyText
+      text="The attack, which Iran said was in retaliation for Israeli strikes that killed senior Hezbollah and Hamas leaders, prompted Israel and the United States to vow a response."
+    />
+  </BlogPost>
+</Story>


### PR DESCRIPTION
## Summary
- `BlogTOC.stories.svelte`'s "Demo" story now renders only `BlogTOC` (matching what the story is meant to document), instead of the full `Headline` + `ClockWall` + `BlogTOC` + `BlogPost` composition.
- The fuller composed example moves to a new `Compositions/Blog` story (`src/compositions/Blog.stories.svelte` + `Blog.mdx`), mirroring the existing `Compositions/Article` pattern, with a smoke-test `play` function asserting each composed piece renders.
- Since the new composition includes `ClockWall` (live wall-clock, redrawn every 10s), it gets the same `chromatic: { disable: true }` treatment applied to `ClockWall.stories.svelte` in #478 — that setting doesn't propagate across files.

## Test plan
- [x] `pnpm lint` / `pnpm format` — clean
- [x] `pnpm test` — 104 tests passing, no regressions
- [x] `pnpm check` — 0 errors (pre-existing warnings only)
- [x] `pnpm build:docs` — Storybook build completes successfully
- [ ] Confirm Chromatic skips the new `Compositions/Blog` story (no live-clock noise) once CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)