### PR TITLE
Let Chromatic baselines advance on main

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+  # Also build on merge, so main gets builds of its own. Without these,
+  # Chromatic has no build on main to promote as the branch's baseline.
+  push:
+    branches:
+      - main
 
 jobs:
   chromatic:
@@ -30,4 +35,3 @@ jobs:
           buildScriptName: 'build:docs'
         env:
           VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.VITE_MAPBOX_ACCESS_TOKEN }}
-          # exitZeroOnChanges: false

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,4 +1,5 @@
 {
+  "autoAcceptChanges": "main",
   "onlyChanged": true,
   "projectId": "Project:64a5c42823795823edcb60f4",
   "zip": true,


### PR DESCRIPTION
## Why

Chromatic only advances a baseline when changes are **accepted** — and this workflow only ran on `pull_request`, so nothing ever established `main` as a baseline. Roughly 40 PRs merged without their changes being accepted, so the most recent *accepted* ancestor is ~50 builds back. Every diff on #479 reads `Baseline Build 582 on chore/update-vite-storybook-svelte`, and both #478 and #479 independently reported ~235 changes — the same backlog measured twice, not new damage.

## What

- **`push: branches: [main]`** so main gets builds of its own on merge.
- **`autoAcceptChanges: "main"`** in `chromatic.config.json` — whatever lands on main becomes the new baseline. Put in the config file rather than the workflow's `with:` block, since that's the documented home for it and the config file is already this repo's source of truth. The value is a branch name, not a boolean, so it only ever fires on main — PR builds still require review.
- Dropped a commented-out `exitZeroOnChanges` that sat under `env:` instead of `with:`, where the action wouldn't have read it as an input.

## Tradeoffs, explicitly

- **Visual changes on main are no longer human-gated.** Review moves entirely to the PR. If a PR merges unreviewed, its changes silently become the baseline. That's the deal being struck to keep PR diffs meaningful.
- **Snapshot usage goes up**, since each merge now adds a main build on top of the PR builds. `onlyChanged: true` (TurboSnap) is already enabled, which should limit the cost to stories actually touched.

## One uncertainty worth watching

With TurboSnap on, the first main build may only snapshot and auto-accept the stories affected by changed files, rather than clearing all ~235 in one pass. If that's what happens the backlog will drain over the next few merges instead of instantly. Worth a look at the first main build after this lands.

## Test plan

- [x] `.github/workflows/chromatic.yaml` parses; triggers resolve to `pull_request` + `push`
- [x] `chromatic.config.json` parses
- [x] `pnpm format` clean
- [ ] After merge: confirm a **Chromatic build runs on main** (it hasn't before) and its changes are auto-accepted
- [ ] Then confirm a PR branched from that merge baselines against the new main build, not 582

🤖 Generated with [Claude Code](https://claude.com/claude-code)