### PR TITLE
Add reusable Mapbox reverse geocoding

### DIFF
--- a/.changeset/bright-maps-return.md
+++ b/.changeset/bright-maps-return.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Add a framework-agnostic Mapbox v6 `reverseGeocode()` helper and an interactive TileMap example.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,54 +5,9 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
-
-concurrency:
-  group: 'pages'
-  cancel-in-progress: true
-
 jobs:
-  publish:
-    name: Publish docs
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm i
-
-      - name: Build all packages
-        run: pnpm run --recursive --if-present build
-
-      - name: Build docs
-        run: pnpm run --if-present build:docs
-        env:
-          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.VITE_MAPBOX_ACCESS_TOKEN }}
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./docs
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  docs:
+    uses: reuters-graphics/action-workflows/.github/workflows/docs.yaml@main
+    secrets: inherit
+    with:
+      node_version: '22'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,9 +5,54 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
 jobs:
-  docs:
-    uses: reuters-graphics/action-workflows/.github/workflows/docs.yaml@main
-    secrets: inherit
-    with:
-      node_version: '22'
+  publish:
+    name: Publish docs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Build all packages
+        run: pnpm run --recursive --if-present build
+
+      - name: Build docs
+        run: pnpm run --if-present build:docs
+        env:
+          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.VITE_MAPBOX_ACCESS_TOKEN }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/components/Geocoder/Geocoder.mdx
+++ b/src/components/Geocoder/Geocoder.mdx
@@ -76,7 +76,7 @@ function cleanup() {
 }
 ```
 
-The helper calls the Mapbox v6 reverse endpoint and returns `GeocodeFeature[]`, ordered from the most specific overlapping feature to the least specific. No result is represented by an empty array. Non-successful HTTP responses reject with an error containing the response status, and an optional `AbortSignal` is passed directly to `fetch`.
+The helper calls the Mapbox v6 reverse endpoint and returns `GeocodeFeature[]`, ordered from the most specific overlapping feature to the least specific. An empty array represents no results. Non-successful HTTP responses reject with an error containing the response status, and an optional `AbortSignal` is passed directly to `fetch`.
 
 `accessToken` is required. The supported reverse options are `country`, `language`, `limit`, `types`, `worldview`, and `permanent`. The reverse `limit` defaults to `1` and has a maximum of `5`; values above `1` require exactly one entry in `types`. See the [official reverse-geocoding reference](https://docs.mapbox.com/api/search/geocoding/#reverse-geocoding) for parameter details.
 

--- a/src/components/Geocoder/Geocoder.mdx
+++ b/src/components/Geocoder/Geocoder.mdx
@@ -6,7 +6,7 @@ import * as GeocoderStories from './Geocoder.stories.svelte';
 
 # Geocoder
 
-The `Geocoder` component provides an autocomplete location search powered by the [Mapbox Geocoding v6 API](https://docs.mapbox.com/api/search/geocoding-v6/). It returns coordinates and a place name via the `onselect` callback.
+The `Geocoder` component provides an autocomplete location search powered by the [Mapbox Geocoding v6 API](https://docs.mapbox.com/api/search/geocoding/). It returns coordinates and a place name via the `onselect` callback.
 
 ```svelte
 <script>
@@ -27,3 +27,57 @@ The `accessToken` prop is required. Look up the Reuters Mapbox token in the team
 To reduce the number of paid geocoding requests, use `minLength` (minimum characters before searching, default `2`) and `debounceMs` (delay after the last keystroke before requesting, default `300`). Raising them fires fewer requests while the user is still typing.
 
 <Canvas of={GeocoderStories.Demo} />
+
+## Reverse geocoding
+
+Use the framework-agnostic `reverseGeocode()` helper to look up the geographic features at a longitude and latitude. It works with any map library; this MapLibre example cancels the previous request when a reader clicks again:
+
+```ts
+import { reverseGeocode } from '@reuters-graphics/graphics-components';
+import type { MapMouseEvent } from 'maplibre-gl';
+
+const MAPBOX_TOKEN = 'your_mapbox_token';
+let activeRequest: AbortController | null = null;
+
+async function handleMapClick(event: MapMouseEvent) {
+  activeRequest?.abort();
+  activeRequest = new AbortController();
+
+  const { lng, lat } = event.lngLat.wrap();
+
+  try {
+    const [feature] = await reverseGeocode(
+      lng,
+      lat,
+      {
+        accessToken: MAPBOX_TOKEN,
+        language: ['en'],
+      },
+      activeRequest.signal
+    );
+
+    if (!feature) {
+      console.log('No named place found');
+      return;
+    }
+
+    console.log(feature.properties.full_address ?? feature.properties.name);
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') return;
+    throw error;
+  }
+}
+
+map.on('click', handleMapClick);
+
+function cleanup() {
+  activeRequest?.abort();
+  map.off('click', handleMapClick);
+}
+```
+
+The helper calls the Mapbox v6 reverse endpoint and returns `GeocodeFeature[]`, ordered from the most specific overlapping feature to the least specific. No result is represented by an empty array. Non-successful HTTP responses reject with an error containing the response status, and an optional `AbortSignal` is passed directly to `fetch`.
+
+`accessToken` is required. The supported reverse options are `country`, `language`, `limit`, `types`, `worldview`, and `permanent`. The reverse `limit` defaults to `1` and has a maximum of `5`; values above `1` require exactly one entry in `types`. See the [official reverse-geocoding reference](https://docs.mapbox.com/api/search/geocoding/#reverse-geocoding) for parameter details.
+
+> **Mapbox storage rules:** Geocoding is temporary by default, and temporary results must not be cached. Temporary requests explicitly bypass the browser HTTP cache. Set `permanent: true` only when you intend to store results and the Mapbox account has a valid credit card on file or an active enterprise contract. This library does not add application-level caching or storage for either response mode.

--- a/src/components/Geocoder/geocode.test.ts
+++ b/src/components/Geocoder/geocode.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  geocode,
+  reverseGeocode,
+  type GeocodeFeature,
+  type GeocodeFeatureType,
+} from './geocode';
+
+const feature: GeocodeFeature = {
+  type: 'Feature',
+  properties: {
+    mapbox_id: 'address.123',
+    feature_type: 'address',
+    name: '20 West 34th Street',
+    full_address: '20 West 34th Street, New York, New York 10118',
+    coordinates: {
+      longitude: -73.9861365,
+      latitude: 40.7488949,
+    },
+    context: {
+      place: { mapbox_id: 'place.123', name: 'New York' },
+    },
+  },
+  geometry: {
+    type: 'Point',
+    coordinates: [-73.9861365, 40.7488949],
+  },
+};
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('reverseGeocode', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('builds a Mapbox v6 reverse request with every supported option', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ features: [feature] }));
+
+    const results = await reverseGeocode(-73.9861365, 40.7488949, {
+      accessToken: 'test-token',
+      country: ['us', 'ca'],
+      language: ['en', 'es'],
+      limit: 3,
+      types: ['address'],
+      worldview: 'us',
+      permanent: true,
+    });
+
+    expect(results).toEqual([feature]);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const [input] = fetchMock.mock.calls[0];
+    const url = new URL(String(input));
+    expect(`${url.origin}${url.pathname}`).toBe(
+      'https://api.mapbox.com/search/geocode/v6/reverse'
+    );
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      longitude: '-73.9861365',
+      latitude: '40.7488949',
+      access_token: 'test-token',
+      country: 'us,ca',
+      language: 'en,es',
+      types: 'address',
+      worldview: 'us',
+      permanent: 'true',
+      limit: '3',
+    });
+    expect(fetchMock.mock.calls[0][1]?.cache).toBe('default');
+  });
+
+  it('bypasses the HTTP cache for temporary results', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ features: [] }));
+
+    await reverseGeocode(0, 0, { accessToken: 'test-token' });
+
+    expect(fetchMock.mock.calls[0][1]?.cache).toBe('no-store');
+  });
+
+  it.each([{ features: [] }, {}])(
+    'returns an empty array when the response has no results',
+    async (response) => {
+      fetchMock.mockResolvedValue(jsonResponse(response));
+
+      await expect(
+        reverseGeocode(0, 0, { accessToken: 'test-token' })
+      ).resolves.toEqual([]);
+    }
+  );
+
+  it('throws the established status error for an HTTP failure', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ message: 'Rate limited' }, 429));
+
+    await expect(
+      reverseGeocode(0, 0, { accessToken: 'test-token' })
+    ).rejects.toThrow('Geocode request failed: 429');
+  });
+
+  it('accepts coordinates at the WGS84 bounds', async () => {
+    fetchMock.mockImplementation(async () => jsonResponse({ features: [] }));
+
+    await reverseGeocode(-180, -90, { accessToken: 'test-token' });
+    await reverseGeocode(180, 90, { accessToken: 'test-token' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ['longitude', Number.NaN, 0],
+    ['longitude', Number.NEGATIVE_INFINITY, 0],
+    ['longitude', -180.0001, 0],
+    ['longitude', 180.0001, 0],
+    ['latitude', 0, Number.NaN],
+    ['latitude', 0, Number.POSITIVE_INFINITY],
+    ['latitude', 0, -90.0001],
+    ['latitude', 0, 90.0001],
+  ])(
+    'rejects an invalid %s before requesting',
+    async (coordinate, longitude, latitude) => {
+      await expect(
+        reverseGeocode(longitude, latitude, { accessToken: 'test-token' })
+      ).rejects.toThrow(`${coordinate} must be a finite number`);
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it('passes through the AbortSignal and does not swallow abort errors', async () => {
+    fetchMock.mockImplementation(async (_input, init) => {
+      await new Promise<void>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () =>
+            reject(new DOMException('The operation was aborted', 'AbortError')),
+          { once: true }
+        );
+      });
+      return jsonResponse({ features: [] });
+    });
+
+    const controller = new AbortController();
+    const request = reverseGeocode(
+      -73.9861365,
+      40.7488949,
+      { accessToken: 'test-token' },
+      controller.signal
+    );
+    controller.abort();
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(controller.signal);
+  });
+
+  it('keeps forward geocoding on the v6 forward endpoint', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ features: [feature] }));
+    const controller = new AbortController();
+    const types: GeocodeFeatureType[] = ['place'];
+
+    await expect(
+      geocode(
+        'New York',
+        {
+          accessToken: 'test-token',
+          autocomplete: false,
+          limit: 1,
+          types,
+        },
+        controller.signal
+      )
+    ).resolves.toEqual([feature]);
+
+    const [input, init] = fetchMock.mock.calls[0];
+    const url = new URL(String(input));
+    expect(`${url.origin}${url.pathname}`).toBe(
+      'https://api.mapbox.com/search/geocode/v6/forward'
+    );
+    expect(url.searchParams.get('q')).toBe('New York');
+    expect(url.searchParams.get('autocomplete')).toBe('false');
+    expect(url.searchParams.get('limit')).toBe('1');
+    expect(url.searchParams.get('types')).toBe('place');
+    expect(init?.signal).toBe(controller.signal);
+    expect(init?.cache).toBe('no-store');
+  });
+});

--- a/src/components/Geocoder/geocode.test.ts
+++ b/src/components/Geocoder/geocode.test.ts
@@ -33,7 +33,7 @@ const jsonResponse = (body: unknown, status = 200) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
-describe('reverseGeocode', () => {
+describe('geocoding helpers', () => {
   const fetchMock = vi.fn<typeof fetch>();
 
   beforeEach(() => {
@@ -134,6 +134,43 @@ describe('reverseGeocode', () => {
       expect(fetchMock).not.toHaveBeenCalled();
     }
   );
+
+  it.each([0, 1.5, 6, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid reverse limit %s before requesting',
+    async (limit) => {
+      await expect(
+        reverseGeocode(0, 0, { accessToken: 'test-token', limit })
+      ).rejects.toThrow('limit must be an integer between 1 and 5');
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it('requires exactly one type when the reverse limit is greater than 1', async () => {
+    await expect(
+      reverseGeocode(0, 0, { accessToken: 'test-token', limit: 2 })
+    ).rejects.toThrow(
+      'types must contain exactly one feature type when limit is greater than 1'
+    );
+    await expect(
+      reverseGeocode(0, 0, {
+        accessToken: 'test-token',
+        limit: 2,
+        types: [],
+      })
+    ).rejects.toThrow(
+      'types must contain exactly one feature type when limit is greater than 1'
+    );
+    await expect(
+      reverseGeocode(0, 0, {
+        accessToken: 'test-token',
+        limit: 2,
+        types: ['address', 'place'],
+      })
+    ).rejects.toThrow(
+      'types must contain exactly one feature type when limit is greater than 1'
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 
   it('passes through the AbortSignal and does not swallow abort errors', async () => {
     fetchMock.mockImplementation(async (_input, init) => {

--- a/src/components/Geocoder/geocode.ts
+++ b/src/components/Geocoder/geocode.ts
@@ -1,3 +1,4 @@
+/** Feature types accepted by both endpoints' `types` filters. */
 export type GeocodeFeatureType =
   | 'country'
   | 'region'
@@ -9,36 +10,61 @@ export type GeocodeFeatureType =
   | 'street'
   | 'address';
 
-export interface GeocodeOptions {
+/** Feature types that may appear in a Mapbox Geocoding v6 response. */
+export type GeocodeResponseFeatureType =
+  | GeocodeFeatureType
+  | 'block'
+  | 'secondary_address';
+
+/** Feature types accepted by the forward endpoint's `types` filter. */
+export type ForwardGeocodeFilterType = GeocodeFeatureType | 'secondary_address';
+
+/** Feature types accepted by the reverse endpoint's `types` filter. */
+export type ReverseGeocodeFilterType = GeocodeFeatureType;
+
+interface BaseGeocodeOptions<T extends GeocodeResponseFeatureType> {
   /** Mapbox public access token. */
   accessToken: string;
+  /** Filter results to one or more countries using ISO 3166-1 alpha-2 codes. */
+  country?: string[];
+  /** IETF language tags for response text. The first tag is the primary language. */
+  language?: string[];
+  /** Filter results by feature type. */
+  types?: T[];
+  /** Geopolitical worldview for boundary representation (e.g. 'us', 'cn', 'in'). Defaults to 'us'. */
+  worldview?: string;
+  /** Set to true only if results will be stored. Temporary results (the default) must not be cached. */
+  permanent?: boolean;
+}
+
+export interface GeocodeOptions
+  extends BaseGeocodeOptions<ForwardGeocodeFilterType> {
   /** Return partial prefix matches (true) or exact matches only (false). Defaults to true. */
   autocomplete?: boolean;
   /** Limit results to a bounding box: [minLon, minLat, maxLon, maxLat]. Cannot cross the 180th meridian. */
   bbox?: [number, number, number, number];
-  /** Filter results to one or more countries using ISO 3166-1 alpha-2 codes. */
-  country?: string[];
-  /** IETF language tags for the response. Also influences result scoring. Max 20. */
-  language?: string[];
   /** Maximum number of results to return (1–10). Defaults to 5. */
   limit?: number;
   /** Bias results toward a location: [lon, lat] coordinates or 'ip' to use the request IP. */
   proximity?: [number, number] | 'ip';
-  /** Filter results by feature type. */
-  types?: GeocodeFeatureType[];
-  /** Geopolitical worldview for boundary representation (e.g. 'us', 'cn', 'in'). Defaults to 'us'. */
-  worldview?: string;
-  /** Set to true if results will be stored/cached permanently. Defaults to false. */
-  permanent?: boolean;
   /** Return building entrance data when available (public preview). Defaults to false. */
   entrances?: boolean;
+}
+
+export interface ReverseGeocodeOptions
+  extends BaseGeocodeOptions<ReverseGeocodeFilterType> {
+  /**
+   * Maximum number of results to return (1–5). Defaults to 1. Values above 1
+   * require exactly one feature type.
+   */
+  limit?: number;
 }
 
 export interface GeocodeFeature {
   type: 'Feature';
   properties: {
     mapbox_id: string;
-    feature_type: GeocodeFeatureType;
+    feature_type: GeocodeResponseFeatureType;
     name: string;
     name_preferred?: string;
     place_formatted?: string;
@@ -55,23 +81,50 @@ export interface GeocodeFeature {
   };
 }
 
-const BASE_URL = 'https://api.mapbox.com/search/geocode/v6/forward';
+const FORWARD_URL = 'https://api.mapbox.com/search/geocode/v6/forward';
+const REVERSE_URL = 'https://api.mapbox.com/search/geocode/v6/reverse';
+
+function appendBaseOptions(
+  params: URLSearchParams,
+  options: BaseGeocodeOptions<GeocodeResponseFeatureType>
+) {
+  params.set('access_token', options.accessToken);
+  if (options.country) params.set('country', options.country.join(','));
+  if (options.language) params.set('language', options.language.join(','));
+  if (options.types) params.set('types', options.types.join(','));
+  if (options.worldview) params.set('worldview', options.worldview);
+  if (options.permanent !== undefined)
+    params.set('permanent', String(options.permanent));
+}
+
+async function requestGeocodeFeatures(
+  url: string,
+  params: URLSearchParams,
+  permanent: boolean,
+  signal?: AbortSignal
+): Promise<GeocodeFeature[]> {
+  const response = await fetch(`${url}?${params}`, {
+    signal,
+    cache: permanent ? 'default' : 'no-store',
+  });
+  if (!response.ok)
+    throw new Error(`Geocode request failed: ${response.status}`);
+
+  const data: { features?: GeocodeFeature[] } = await response.json();
+  return data.features ?? [];
+}
 
 export async function geocode(
   query: string,
   options: GeocodeOptions,
   signal?: AbortSignal
 ): Promise<GeocodeFeature[]> {
-  const params = new URLSearchParams({
-    q: query,
-    access_token: options.accessToken,
-  });
+  const params = new URLSearchParams({ q: query });
+  appendBaseOptions(params, options);
 
   if (options.autocomplete !== undefined)
     params.set('autocomplete', String(options.autocomplete));
   if (options.bbox) params.set('bbox', options.bbox.join(','));
-  if (options.country) params.set('country', options.country.join(','));
-  if (options.language) params.set('language', options.language.join(','));
   if (options.limit !== undefined) params.set('limit', String(options.limit));
   if (options.proximity)
     params.set(
@@ -80,15 +133,56 @@ export async function geocode(
         options.proximity.join(',')
       : options.proximity
     );
-  if (options.types) params.set('types', options.types.join(','));
-  if (options.worldview) params.set('worldview', options.worldview);
-  if (options.permanent !== undefined)
-    params.set('permanent', String(options.permanent));
   if (options.entrances !== undefined)
     params.set('entrances', String(options.entrances));
 
-  const res = await fetch(`${BASE_URL}?${params}`, { signal });
-  if (!res.ok) throw new Error(`Geocode request failed: ${res.status}`);
-  const data = await res.json();
-  return data.features ?? [];
+  return requestGeocodeFeatures(
+    FORWARD_URL,
+    params,
+    options.permanent === true,
+    signal
+  );
+}
+
+function validateCoordinate(
+  name: 'longitude' | 'latitude',
+  value: number,
+  min: number,
+  max: number
+) {
+  if (!Number.isFinite(value) || value < min || value > max) {
+    throw new RangeError(
+      `${name} must be a finite number between ${min} and ${max}`
+    );
+  }
+}
+
+/**
+ * Look up the geographic features at a WGS84 longitude/latitude coordinate.
+ *
+ * Results are ordered from the most specific feature to the least specific.
+ * Temporary results are returned by default and must not be cached.
+ */
+export async function reverseGeocode(
+  longitude: number,
+  latitude: number,
+  options: ReverseGeocodeOptions,
+  signal?: AbortSignal
+): Promise<GeocodeFeature[]> {
+  validateCoordinate('longitude', longitude, -180, 180);
+  validateCoordinate('latitude', latitude, -90, 90);
+
+  const params = new URLSearchParams({
+    longitude: String(longitude),
+    latitude: String(latitude),
+  });
+  appendBaseOptions(params, options);
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+
+  return requestGeocodeFeatures(
+    REVERSE_URL,
+    params,
+    options.permanent === true,
+    signal
+  );
 }

--- a/src/components/Geocoder/geocode.ts
+++ b/src/components/Geocoder/geocode.ts
@@ -157,6 +157,23 @@ function validateCoordinate(
   }
 }
 
+function validateReverseOptions(options: ReverseGeocodeOptions) {
+  if (
+    options.limit !== undefined &&
+    (!Number.isInteger(options.limit) || options.limit < 1 || options.limit > 5)
+  ) {
+    throw new RangeError('limit must be an integer between 1 and 5');
+  }
+
+  if (options.limit !== undefined && options.limit > 1) {
+    if (options.types?.length !== 1) {
+      throw new TypeError(
+        'types must contain exactly one feature type when limit is greater than 1'
+      );
+    }
+  }
+}
+
 /**
  * Look up the geographic features at a WGS84 longitude/latitude coordinate.
  *
@@ -171,6 +188,7 @@ export async function reverseGeocode(
 ): Promise<GeocodeFeature[]> {
   validateCoordinate('longitude', longitude, -180, 180);
   validateCoordinate('latitude', latitude, -90, 90);
+  validateReverseOptions(options);
 
   const params = new URLSearchParams({
     longitude: String(longitude),

--- a/src/components/TileMap/TileMap.mdx
+++ b/src/components/TileMap/TileMap.mdx
@@ -281,6 +281,73 @@ Use `TileMapCallout` when you want a framed annotation attached to a map coordin
 - **id**: `string` - Add an id to the MapLibre marker wrapper
 - **children**: `Snippet` - Short label or compact rich content
 
+## Forward geocoding (search and fly)
+
+Use `Geocoder` inside `TileMap` when you want readers to search for a place name and then move the map there. The story below wires `onselect` to `map.flyTo()`.
+
+<Canvas of={TileMapStories.WithGeocoder} />
+
+```svelte
+<script lang="ts">
+  import { Geocoder, TileMap } from '@reuters-graphics/graphics-components';
+  import type { Map as MapType } from 'maplibre-gl';
+
+  const mapboxAccessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? '';
+  let mapRef: MapType;
+</script>
+
+<TileMap
+  id="geocoder-map"
+  center={[-98, 39]}
+  zoom={3}
+  interactive
+  onMapReady={(map) => {
+    mapRef = map;
+  }}
+>
+  <Geocoder
+    accessToken={mapboxAccessToken}
+    onselect={(loc) => {
+      mapRef?.flyTo({ center: [loc.lng, loc.lat], zoom: 10 });
+    }}
+  />
+</TileMap>
+```
+
+`accessToken` is required for geocoding requests. In Storybook docs builds, set `VITE_MAPBOX_ACCESS_TOKEN` so the search box can call Mapbox.
+
+## Reverse geocoding (click and identify)
+
+Use reverse geocoding when the interaction starts from a map coordinate instead of typed text. This pattern listens for a map click, calls `reverseGeocode()`, and displays the nearest named feature.
+
+<Canvas of={TileMapStories.ReverseGeocodingOnClick} />
+
+```ts
+import { reverseGeocode } from '@reuters-graphics/graphics-components';
+import type { MapMouseEvent } from 'maplibre-gl';
+
+const accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? '';
+let activeRequest: AbortController | null = null;
+
+async function handleMapClick(event: MapMouseEvent) {
+  activeRequest?.abort();
+  activeRequest = new AbortController();
+
+  const { lng, lat } = event.lngLat.wrap();
+  const [feature] = await reverseGeocode(
+    lng,
+    lat,
+    { accessToken, language: ['en'] },
+    activeRequest.signal
+  );
+
+  if (!feature) return;
+  console.log(feature.properties.full_address ?? feature.properties.name);
+}
+```
+
+This keeps the lookup framework-agnostic: `TileMap` handles map rendering, while `reverseGeocode()` handles the API call and typed response data.
+
 ## Advanced usage
 
 For more control over the map, you can use the `onMapReady` callback to access the MapLibre GL instance:

--- a/src/components/TileMap/TileMap.mdx
+++ b/src/components/TileMap/TileMap.mdx
@@ -352,10 +352,10 @@ Use reverse geocoding when the interaction starts from a map coordinate instead 
       activeRequest.signal
     );
 
-    selectedLabel = feature ?
-      (feature.properties.full_address ?? feature.properties.name)
-    :
-      'No named place found';
+    selectedLabel =
+      feature ?
+        (feature.properties.full_address ?? feature.properties.name)
+      : 'No named place found';
   }
 </script>
 

--- a/src/components/TileMap/TileMap.mdx
+++ b/src/components/TileMap/TileMap.mdx
@@ -322,28 +322,56 @@ Use reverse geocoding when the interaction starts from a map coordinate instead 
 
 <Canvas of={TileMapStories.ReverseGeocodingOnClick} />
 
-```ts
-import { reverseGeocode } from '@reuters-graphics/graphics-components';
-import type { MapMouseEvent } from 'maplibre-gl';
+```svelte
+<script lang="ts">
+  import {
+    TileMap,
+    TileMapCallout,
+    reverseGeocode,
+  } from '@reuters-graphics/graphics-components';
+  import type { MapMouseEvent } from 'maplibre-gl';
 
-const accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? '';
-let activeRequest: AbortController | null = null;
+  const accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? '';
+  let activeRequest: AbortController | null = null;
 
-async function handleMapClick(event: MapMouseEvent) {
-  activeRequest?.abort();
-  activeRequest = new AbortController();
+  let selectedLngLat: [number, number] | null = null;
+  let selectedLabel = '';
 
-  const { lng, lat } = event.lngLat.wrap();
-  const [feature] = await reverseGeocode(
-    lng,
-    lat,
-    { accessToken, language: ['en'] },
-    activeRequest.signal
-  );
+  async function handleMapClick(event: MapMouseEvent) {
+    activeRequest?.abort();
+    activeRequest = new AbortController();
 
-  if (!feature) return;
-  console.log(feature.properties.full_address ?? feature.properties.name);
-}
+    const { lng, lat } = event.lngLat.wrap();
+    selectedLngLat = [lng, lat];
+    selectedLabel = 'Looking up location...';
+
+    const [feature] = await reverseGeocode(
+      lng,
+      lat,
+      { accessToken, language: ['en'] },
+      activeRequest.signal
+    );
+
+    selectedLabel = feature ?
+      (feature.properties.full_address ?? feature.properties.name)
+    :
+      'No named place found';
+  }
+</script>
+
+<TileMap
+  id="reverse-map"
+  center={[-98, 39]}
+  zoom={3}
+  interactive
+  onClick={handleMapClick}
+>
+  {#if selectedLngLat}
+    <TileMapCallout lngLat={selectedLngLat} placement="below">
+      {selectedLabel}
+    </TileMapCallout>
+  {/if}
+</TileMap>
 ```
 
 This keeps the lookup framework-agnostic: `TileMap` handles map rendering, while `reverseGeocode()` handles the API call and typed response data.

--- a/src/components/TileMap/TileMap.stories.svelte
+++ b/src/components/TileMap/TileMap.stories.svelte
@@ -4,6 +4,7 @@
   import TileMapLayer from './TileMapLayer.svelte';
   import TileMapCallout from '../TileMapCallout/TileMapCallout.svelte';
   import Geocoder from '../Geocoder/Geocoder.svelte';
+  import ReverseGeocodeMap from './demo/ReverseGeocodeMap.svelte';
   import type { FeatureCollection, Polygon, Point } from 'geojson';
 
   // Example GeoJSON data - Central Park polygon
@@ -353,4 +354,8 @@
       />
     </div>
   </TileMap>
+</Story>
+
+<Story asChild name="Reverse geocoding on click">
+  <ReverseGeocodeMap accessToken={mapboxAccessToken} />
 </Story>

--- a/src/components/TileMap/demo/ReverseGeocodeMap.svelte
+++ b/src/components/TileMap/demo/ReverseGeocodeMap.svelte
@@ -30,18 +30,6 @@
     : lookupState === 'error' ? 'Location lookup failed'
     : placeName
   );
-  let statusMessage = $derived(
-    !hasAccessToken ?
-      'Set VITE_MAPBOX_ACCESS_TOKEN to enable reverse geocoding in this story.'
-    : lookupState === 'idle' ?
-      'Click the map, or focus it and press Enter or Space, to identify a location.'
-    : lookupState === 'loading' ? 'Looking up the selected location.'
-    : lookupState === 'empty' ?
-      'Mapbox returned no named place for the selected location.'
-    : lookupState === 'error' ?
-      'Mapbox could not look up the selected location. Try another point.'
-    : `Selected location: ${placeName}`
-  );
 
   function getPlaceName(feature: GeocodeFeature) {
     if (feature.properties.full_address) {
@@ -143,10 +131,6 @@
   });
 </script>
 
-{#snippet status()}
-  <p class="status" role="status" aria-live="polite">{statusMessage}</p>
-{/snippet}
-
 <TileMap
   id="reverse-geocode-map"
   center={[-73.9868, 40.7567]}
@@ -156,20 +140,9 @@
   description="Click the map to reverse-geocode that coordinate, or focus the map and press Enter or Space to use its center."
   notes="This example uses temporary geocoding and does not cache responses."
   height="500px"
-  legend={status}
   onMapReady={handleMapReady}
 >
   {#if coordinates}
     <TileMapCallout lngLat={coordinates}>{calloutText}</TileMapCallout>
   {/if}
 </TileMap>
-
-<style>
-  .status {
-    margin: 0;
-    color: var(--theme-colour-text-secondary, #666);
-    font-family: var(--theme-font-family-sans-serif, Arial, sans-serif);
-    font-size: var(--theme-font-size-xs, 0.875rem);
-    line-height: 1.4;
-  }
-</style>

--- a/src/components/TileMap/demo/ReverseGeocodeMap.svelte
+++ b/src/components/TileMap/demo/ReverseGeocodeMap.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import type { Map as MaplibreMap, MapMouseEvent } from 'maplibre-gl';
+  import { reverseGeocode, type GeocodeFeature } from '../../Geocoder/geocode';
+  import TileMapCallout from '../../TileMapCallout/TileMapCallout.svelte';
+  import TileMap from '../TileMap.svelte';
+
+  interface Props {
+    accessToken: string;
+  }
+
+  let { accessToken }: Props = $props();
+
+  type LookupState = 'idle' | 'loading' | 'success' | 'empty' | 'error';
+
+  let coordinates = $state<[number, number] | null>(null);
+  let lookupState = $state<LookupState>('idle');
+  let placeName = $state('');
+
+  let map: MaplibreMap | null = null;
+  let mapCanvas: HTMLCanvasElement | null = null;
+  let activeRequest: AbortController | null = null;
+  let latestRequestId = 0;
+
+  let hasAccessToken = $derived(accessToken.trim().length > 0);
+  let calloutText = $derived(
+    !hasAccessToken ? 'Mapbox token required'
+    : lookupState === 'loading' ? 'Looking up location...'
+    : lookupState === 'empty' ? 'No named place found'
+    : lookupState === 'error' ? 'Location lookup failed'
+    : placeName
+  );
+  let statusMessage = $derived(
+    !hasAccessToken ?
+      'Set VITE_MAPBOX_ACCESS_TOKEN to enable reverse geocoding in this story.'
+    : lookupState === 'idle' ?
+      'Click the map, or focus it and press Enter or Space, to identify a location.'
+    : lookupState === 'loading' ? 'Looking up the selected location.'
+    : lookupState === 'empty' ?
+      'Mapbox returned no named place for the selected location.'
+    : lookupState === 'error' ?
+      'Mapbox could not look up the selected location. Try another point.'
+    : `Selected location: ${placeName}`
+  );
+
+  function getPlaceName(feature: GeocodeFeature) {
+    if (feature.properties.full_address) {
+      return feature.properties.full_address;
+    }
+
+    return [
+      feature.properties.name_preferred ?? feature.properties.name,
+      feature.properties.place_formatted,
+    ]
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  function isAbortError(error: unknown) {
+    return error instanceof DOMException && error.name === 'AbortError';
+  }
+
+  async function lookupLocation(lng: number, lat: number) {
+    const requestId = ++latestRequestId;
+
+    activeRequest?.abort();
+    activeRequest = null;
+    coordinates = [lng, lat];
+    placeName = '';
+
+    if (!hasAccessToken) {
+      lookupState = 'error';
+      return;
+    }
+
+    const controller = new AbortController();
+    activeRequest = controller;
+    lookupState = 'loading';
+
+    try {
+      const [feature] = await reverseGeocode(
+        lng,
+        lat,
+        {
+          accessToken,
+          language: ['en'],
+        },
+        controller.signal
+      );
+
+      if (requestId !== latestRequestId) return;
+
+      if (!feature) {
+        lookupState = 'empty';
+        return;
+      }
+
+      placeName = getPlaceName(feature);
+      lookupState = 'success';
+    } catch (error) {
+      if (requestId !== latestRequestId || isAbortError(error)) return;
+      lookupState = 'error';
+    } finally {
+      if (requestId === latestRequestId) activeRequest = null;
+    }
+  }
+
+  function handleMapClick(event: MapMouseEvent) {
+    const { lng, lat } = event.lngLat.wrap();
+    void lookupLocation(lng, lat);
+  }
+
+  function handleMapKeydown(event: KeyboardEvent) {
+    if (event.repeat || (event.key !== 'Enter' && event.key !== ' ') || !map) {
+      return;
+    }
+
+    event.preventDefault();
+    const { lng, lat } = map.getCenter().wrap();
+    void lookupLocation(lng, lat);
+  }
+
+  function removeMapListeners() {
+    map?.off('click', handleMapClick);
+    mapCanvas?.removeEventListener('keydown', handleMapKeydown);
+    mapCanvas = null;
+  }
+
+  function handleMapReady(mapInstance: MaplibreMap) {
+    removeMapListeners();
+    map = mapInstance;
+    mapCanvas = map.getCanvas();
+    mapCanvas.style.cursor = 'crosshair';
+    mapCanvas.addEventListener('keydown', handleMapKeydown);
+    map.on('click', handleMapClick);
+  }
+
+  onDestroy(() => {
+    latestRequestId += 1;
+    activeRequest?.abort();
+    removeMapListeners();
+    map = null;
+  });
+</script>
+
+{#snippet status()}
+  <p class="status" role="status" aria-live="polite">{statusMessage}</p>
+{/snippet}
+
+<TileMap
+  id="reverse-geocode-map"
+  center={[-73.9868, 40.7567]}
+  zoom={11}
+  interactive
+  title="Identify a place from a map click"
+  description="Click the map to reverse-geocode that coordinate, or focus the map and press Enter or Space to use its center."
+  notes="This example uses temporary geocoding and does not cache responses."
+  height="500px"
+  legend={status}
+  onMapReady={handleMapReady}
+>
+  {#if coordinates}
+    <TileMapCallout lngLat={coordinates}>{calloutText}</TileMapCallout>
+  {/if}
+</TileMap>
+
+<style>
+  .status {
+    margin: 0;
+    color: var(--theme-colour-text-secondary, #666);
+    font-family: var(--theme-font-family-sans-serif, Arial, sans-serif);
+    font-size: var(--theme-font-size-xs, 0.875rem);
+    line-height: 1.4;
+  }
+</style>

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export type { FaqItem } from './components/FaqBox/types';
 export { default as FeaturePhoto } from './components/FeaturePhoto/FeaturePhoto.svelte';
 export { default as Framer } from './components/Framer/Framer.svelte';
 export { default as Geocoder } from './components/Geocoder/Geocoder.svelte';
-export { geocode } from './components/Geocoder/geocode';
+export { geocode, reverseGeocode } from './components/Geocoder/geocode';
 export { default as GraphicBlock } from './components/GraphicBlock/GraphicBlock.svelte';
 export { default as Headline } from './components/Headline/Headline.svelte';
 export { default as Headpile } from './components/Headpile/Headpile.svelte';
@@ -146,8 +146,12 @@ export type {
 
 export type {
   GeocodeOptions,
+  ReverseGeocodeOptions,
   GeocodeFeature,
   GeocodeFeatureType,
+  GeocodeResponseFeatureType,
+  ForwardGeocodeFilterType,
+  ReverseGeocodeFilterType,
 } from './components/Geocoder/geocode';
 
 export type {


### PR DESCRIPTION
### What's in this pull request

Adds a framework-agnostic Mapbox Geocoding v6 `reverseGeocode()` helper alongside the existing forward helper. It uses explicit token/options/`AbortSignal` injection, validates WGS84 coordinates, returns typed `GeocodeFeature[]` results, preserves HTTP/abort errors, and bypasses the HTTP cache for temporary requests.

```ts
const [feature] = await reverseGeocode(
  longitude,
  latitude,
  { accessToken, language: ['en'] },
  signal
);
```

The PR also adds endpoint-specific filter types, complete v6 response feature types, deterministic request/error/abort tests, public exports, generated-doc source, a minor changeset, and an accessible `TileMap` + `TileMapCallout` Storybook example with loading, empty, error, missing-token, keyboard, cleanup, and stale-response handling.

**Mapbox storage caveat:** Temporary geocoding is the default and temporary results must not be cached. `permanent: true` should be used only when results will be stored and the Mapbox account has an eligible billing setup or enterprise contract. The helper adds no application-level storage or cache.

### Test results

- `pnpm lint`
- `pnpm format`
- `pnpm test` - 136 tests passed
- `pnpm check` - 0 errors (17 existing warnings)
- `pnpm build` - package, LLM docs, and publint passed
- `pnpm build:docs` - Storybook build passed
- Browser exercise of missing-token, loading, success, empty, HTTP error, rapid-click/stale-response, desktop/mobile, and keyboard flows
- Lighthouse accessibility: 100

### Before submitting, please check that you've ...

- [x] Read the contributing guide
- [x] Documented the new feature
- [x] Tagged an editor to review this PR