### PR TITLE
Add ArcDatawrapperColumns for ArcCluster

### DIFF
--- a/src/components/ArcCluster/ArcCluster.mdx
+++ b/src/components/ArcCluster/ArcCluster.mdx
@@ -11,6 +11,7 @@ import * as ArcClusterStories from './ArcCluster.stories.svelte';
 The kit has three pieces you can use directly:
 
 - **`ArcCluster`** — the frame: header, a positioned `stage` for your visual, and an optional footer. It loads the Reuters Knowledge font for you.
+- **`ArcDatawrapperColumns`** — the Arc two-up Datawrapper layout: Reuters-style responsive columns, `.datawrapper` iframe styling and Datawrapper `postMessage` height syncing.
 - **`ArcHeader`** — a homepage-style title block with an optional kicker, headline and dek.
 - **`ArcKicker`** — the focused kicker subcomponent used by `ArcHeader`, exported for cases where you need that Reuters.com label pattern outside the standard header.
 
@@ -88,7 +89,7 @@ Unlike the fixed-height Demo above — where the photo is cropped to fill a set 
 
 ## Two-column Datawrapper embed
 
-A common pattern on the homepage, topic pages or section fronts is two charts side by side that stack on narrow screens. Set `stageHeight="auto"` so the stage grows with the charts, drop two [`DatawrapperChart`](/docs/components-graphics-datawrapperchart--docs) components (each `width="fluid"`) into a responsive CSS grid, and leave off `title`/`description`/`notes` so each chart uses its own built-in headline and footer.
+A common pattern on the homepage, topic pages or section fronts is two charts side by side that stack on narrow screens. Set `stageHeight="auto"` so the stage grows with the charts, then use `ArcDatawrapperColumns` to package the layout CSS and Datawrapper message-based height syncing.
 
 Two charts with different chrome — here the transits chart carries a legend the crude chart doesn't — report different heights, so their columns won't line up. Fix it in two parts: give both a matching `height` prop to pin their frames to the same size, and add [`?fitchart=true`](https://developer.datawrapper.de/docs/render-flags) to each chart's `src` so Datawrapper stretches the plot to fill that fixed height instead of leaving whitespace under the shorter chart. The footers and plot areas then line up.
 
@@ -98,59 +99,32 @@ Two charts with different chrome — here the transits chart carries a legend th
 <script>
   import {
     ArcCluster,
-    DatawrapperChart,
+    ArcDatawrapperColumns,
   } from '@reuters-graphics/graphics-components';
 </script>
 
 <ArcCluster stageHeight="auto">
   {#snippet stage()}
-    <div class="dw-columns">
-      <DatawrapperChart
-        width="fluid"
-        textWidth="fluid"
-        src="https://datawrapper.dwcdn.net/8lZUu/?fitchart=true"
-        frameTitle="Crude oil at sea"
-        ariaLabel="Chart: crude oil at sea"
-        id="dw-8lZUu"
-        scrolling="no"
-        height={470}
-      />
-      <DatawrapperChart
-        width="fluid"
-        textWidth="fluid"
-        src="https://datawrapper.dwcdn.net/GEfzN/?fitchart=true"
-        frameTitle="Oil-tanker transits through the Strait of Hormuz"
-        ariaLabel="Chart: oil-tanker transits through the Strait of Hormuz"
-        id="dw-GEfzN"
-        scrolling="no"
-        height={470}
-      />
-    </div>
+    <ArcDatawrapperColumns
+      charts={[
+        {
+          frameTitle: 'Crude oil at sea',
+          ariaLabel: 'Chart: crude oil at sea',
+          id: 'dw-8lZUu',
+          src: 'https://datawrapper.dwcdn.net/8lZUu/?fitchart=true',
+          height: 470,
+        },
+        {
+          frameTitle: 'Oil-tanker transits through the Strait of Hormuz',
+          ariaLabel: 'Chart: oil-tanker transits through the Strait of Hormuz',
+          id: 'dw-GEfzN',
+          src: 'https://datawrapper.dwcdn.net/GEfzN/?fitchart=true',
+          height: 470,
+        },
+      ]}
+    />
   {/snippet}
 </ArcCluster>
-
-<style>
-  .dw-columns {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-  }
-
-  /* DatawrapperChart wraps each chart in a GraphicBlock whose `fluid` width
-     adds full-bleed horizontal margins and extra width to break out of the
-     text well; contain it so each chart sits flush inside its grid cell. */
-  .dw-columns :global(.graphic) {
-    width: 100%;
-    margin: 0;
-  }
-
-  /* Stack on narrow screens. */
-  @media (max-width: 600px) {
-    .dw-columns {
-      grid-template-columns: 1fr;
-    }
-  }
-</style>
 ```
 
 ## Fonts

--- a/src/components/ArcCluster/ArcCluster.mdx
+++ b/src/components/ArcCluster/ArcCluster.mdx
@@ -8,7 +8,7 @@ import * as ArcClusterStories from './ArcCluster.stories.svelte';
 
 `ArcCluster` is a small, reusable starter kit for building iframed embeds for the **Arc** content management system that runs Reuters.com. It supplies the shared chrome — a light `Theme`, the Reuters Knowledge font, [Pym.js](https://blog.apps.npr.org/pym.js/) iframe resizing and a simple stacked layout — with no styling tied to any one graphic, so you can drop your own header, stage (the main visual) and footer into named snippets and match the look of the homepage.
 
-The kit has three pieces you can use directly:
+The kit has four pieces you can use directly:
 
 - **`ArcCluster`** — the frame: header, a positioned `stage` for your visual, and an optional footer. It loads the Reuters Knowledge font for you.
 - **`ArcDatawrapperColumns`** — the Arc two-up Datawrapper layout: Reuters-style responsive columns, `.datawrapper` iframe styling and Datawrapper `postMessage` height syncing.

--- a/src/components/ArcCluster/ArcCluster.stories.svelte
+++ b/src/components/ArcCluster/ArcCluster.stories.svelte
@@ -17,7 +17,7 @@
   // Reuse an existing Storybook image asset for the basic stage, standing in for
   // whatever graphic (a map, chart or photo) an embed would render.
   import sharkSrc from '../FeaturePhoto/images/shark.jpg';
-  import DatawrapperChart from '../DatawrapperChart/DatawrapperChart.svelte';
+  import ArcDatawrapperColumns from './ArcDatawrapperColumns.svelte';
 </script>
 
 <!--
@@ -109,28 +109,27 @@
 <Story asChild name="Two-column Datawrapper" exportName="TwoColumnDatawrapper">
   <ArcCluster stageHeight="auto">
     {#snippet stage()}
-      <div class="arc-dw-columns">
-        <DatawrapperChart
-          width="fluid"
-          textWidth="fluid"
-          src="https://datawrapper.dwcdn.net/8lZUu/?fitchart=true"
-          frameTitle="Crude oil at sea"
-          ariaLabel="Chart: crude oil at sea"
-          id="arc-dw-8lZUu"
-          scrolling="no"
-          height={470}
-        />
-        <DatawrapperChart
-          width="fluid"
-          textWidth="fluid"
-          src="https://datawrapper.dwcdn.net/GEfzN/?fitchart=true"
-          frameTitle="Oil-tanker transits through the Strait of Hormuz"
-          ariaLabel="Chart: oil-tanker transits through the Strait of Hormuz"
-          id="arc-dw-GEfzN"
-          scrolling="no"
-          height={470}
-        />
-      </div>
+      <ArcDatawrapperColumns
+        charts={[
+          {
+            frameTitle: 'Crude oil at sea',
+            ariaLabel: 'Chart: crude oil at sea',
+            id: 'arc-dw-8lZUu',
+            src: 'https://datawrapper.dwcdn.net/8lZUu/?fitchart=true',
+            scrolling: 'no',
+            height: 470,
+          },
+          {
+            frameTitle: 'Oil-tanker transits through the Strait of Hormuz',
+            ariaLabel:
+              'Chart: oil-tanker transits through the Strait of Hormuz',
+            id: 'arc-dw-GEfzN',
+            src: 'https://datawrapper.dwcdn.net/GEfzN/?fitchart=true',
+            scrolling: 'no',
+            height: 470,
+          },
+        ]}
+      />
     {/snippet}
   </ArcCluster>
 </Story>
@@ -177,25 +176,6 @@
 
     span {
       color: #999;
-    }
-  }
-
-  .arc-dw-columns {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-
-    // DatawrapperChart wraps each chart in a GraphicBlock whose `fluid` width
-    // adds full-bleed horizontal margins and extra width to break out of the
-    // text well; contain it so each chart sits flush inside its grid cell.
-    :global(.graphic) {
-      width: 100%;
-      margin: 0;
-    }
-
-    // Stack on narrow screens.
-    @media (max-width: 600px) {
-      grid-template-columns: 1fr;
     }
   }
 </style>

--- a/src/components/ArcCluster/ArcDatawrapperColumns.svelte
+++ b/src/components/ArcCluster/ArcDatawrapperColumns.svelte
@@ -45,10 +45,11 @@
 
     if (!datawrapperHeights || typeof datawrapperHeights !== 'object') return;
 
-    const iframes =
+    const iframes = Array.from(
       containerElement?.querySelectorAll<HTMLIFrameElement>(
         'iframe.datawrapper'
-      );
+      ) ?? []
+    );
     if (!iframes?.length) return;
 
     for (const chartId in datawrapperHeights as Record<string, number>) {

--- a/src/components/ArcCluster/ArcDatawrapperColumns.svelte
+++ b/src/components/ArcCluster/ArcDatawrapperColumns.svelte
@@ -17,7 +17,10 @@
     src: string;
     /** iframe scrolling option */
     scrolling?: ScrollingOption;
-    /** Optional initial/fallback iframe height in pixels */
+    /**
+     * Optional fixed iframe height in pixels. When set, postMessage-based
+     * resizing is skipped for that chart so paired columns can stay aligned.
+     */
     height?: number;
   }
 
@@ -60,6 +63,8 @@
 
       for (const iframe of iframes) {
         if (iframe.contentWindow === event.source) {
+          // Respect fixed heights for aligned two-up layouts.
+          if (iframe.hasAttribute('height')) continue;
           iframe.style.height = `${reportedHeight}px`;
         }
       }
@@ -92,6 +97,7 @@
         src={chart.src}
         scrolling={chart.scrolling ?? 'no'}
         frameborder="0"
+        data-chromatic="ignore"
         data-external="1"
         height={chart.height}
       ></iframe>

--- a/src/components/ArcCluster/ArcDatawrapperColumns.svelte
+++ b/src/components/ArcCluster/ArcDatawrapperColumns.svelte
@@ -1,0 +1,131 @@
+<!--
+  @component A two-column Datawrapper layout for ArcCluster embeds with built-in responsive stacking and Datawrapper postMessage height syncing.
+-->
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+
+  type ScrollingOption = 'auto' | 'yes' | 'no';
+
+  export interface ArcDatawrapperChart {
+    /** iframe title */
+    frameTitle: string;
+    /** iframe aria label */
+    ariaLabel: string;
+    /** iframe id */
+    id: string;
+    /** Datawrapper embed URL */
+    src: string;
+    /** iframe scrolling option */
+    scrolling?: ScrollingOption;
+    /** Optional initial/fallback iframe height in pixels */
+    height?: number;
+  }
+
+  interface Props {
+    /** Two charts for the standard Reuters Arc two-column pattern. */
+    charts: [ArcDatawrapperChart, ArcDatawrapperChart];
+    /** Gap between columns in pixels. */
+    gap?: number;
+    /** Extra class on the root element. */
+    class?: string;
+  }
+
+  let { charts, gap = 24, class: cls = '' }: Props = $props();
+
+  let containerElement: HTMLDivElement | undefined;
+
+  const frameFiller = (event: MessageEvent) => {
+    const messageData = event.data;
+    let datawrapperHeights: unknown;
+    if (messageData && typeof messageData === 'object') {
+      datawrapperHeights = (messageData as Record<string, unknown>)[
+        'datawrapper-height'
+      ];
+    }
+
+    if (!datawrapperHeights || typeof datawrapperHeights !== 'object') return;
+
+    const iframes =
+      containerElement?.querySelectorAll<HTMLIFrameElement>(
+        'iframe.datawrapper'
+      );
+    if (!iframes?.length) return;
+
+    for (const chartId in datawrapperHeights as Record<string, number>) {
+      const reportedHeight = (datawrapperHeights as Record<string, number>)[
+        chartId
+      ];
+      if (!Number.isFinite(reportedHeight)) continue;
+
+      for (const iframe of iframes) {
+        if (iframe.contentWindow === event.source) {
+          iframe.style.height = `${reportedHeight}px`;
+        }
+      }
+    }
+  };
+
+  onMount(() => {
+    if (typeof window === 'undefined') return;
+    window.addEventListener('message', frameFiller);
+  });
+
+  onDestroy(() => {
+    if (typeof window === 'undefined') return;
+    window.removeEventListener('message', frameFiller);
+  });
+</script>
+
+<div
+  bind:this={containerElement}
+  class="embed--container {cls}"
+  style={`--arc-datawrapper-gap: ${gap}px;`}
+>
+  {#each charts as chart (chart.id)}
+    <div class="embed--column">
+      <iframe
+        class="datawrapper"
+        title={chart.frameTitle}
+        aria-label={chart.ariaLabel}
+        id={chart.id}
+        src={chart.src}
+        scrolling={chart.scrolling ?? 'no'}
+        frameborder="0"
+        data-external="1"
+        height={chart.height}
+      ></iframe>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .embed--container {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: var(--arc-datawrapper-gap, 24px);
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  .embed--column {
+    flex: 1 1 calc((100% - var(--arc-datawrapper-gap, 24px)) / 2);
+    min-width: 0;
+  }
+
+  .datawrapper {
+    width: 0;
+    min-width: 100% !important;
+    border: none;
+  }
+
+  @media (max-width: 768px) {
+    .embed--column {
+      flex-basis: 100%;
+      align-self: flex-start;
+    }
+  }
+</style>

--- a/src/components/ArcCluster/ArcDatawrapperColumns.test.ts
+++ b/src/components/ArcCluster/ArcDatawrapperColumns.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { render } from 'svelte/server';
+import ArcDatawrapperColumns from './ArcDatawrapperColumns.svelte';
+
+describe('ArcDatawrapperColumns', () => {
+  it('renders the Reuters Arc two-column Datawrapper markup contract', () => {
+    const { body } = render(ArcDatawrapperColumns, {
+      props: {
+        charts: [
+          {
+            frameTitle: 'Chart one',
+            ariaLabel: 'Chart one',
+            id: 'dw-1',
+            src: 'https://datawrapper.dwcdn.net/abcde/1/',
+            height: 470,
+          },
+          {
+            frameTitle: 'Chart two',
+            ariaLabel: 'Chart two',
+            id: 'dw-2',
+            src: 'https://datawrapper.dwcdn.net/fghij/1/',
+            height: 470,
+          },
+        ],
+      },
+    });
+
+    expect(body).toContain('class="embed--container');
+    expect(body).toContain('class="embed--column');
+    expect(body).toContain('class="datawrapper ');
+    expect(body).toContain('data-external="1"');
+  });
+
+  it('keeps the bundled datawrapper CSS and message-listener contract in source', () => {
+    const source = readFileSync(
+      new URL('./ArcDatawrapperColumns.svelte', import.meta.url),
+      'utf8'
+    );
+
+    expect(source).toContain("'iframe.datawrapper'");
+    expect(source).toContain("window.addEventListener('message', frameFiller)");
+    expect(source).toContain('.datawrapper {');
+    expect(source).toContain('min-width: 100% !important;');
+    expect(source).toContain('@media (max-width: 768px)');
+  });
+});

--- a/src/components/ArcCluster/ArcDatawrapperColumns.test.ts
+++ b/src/components/ArcCluster/ArcDatawrapperColumns.test.ts
@@ -29,6 +29,7 @@ describe('ArcDatawrapperColumns', () => {
     expect(body).toContain('class="embed--container');
     expect(body).toContain('class="embed--column');
     expect(body).toContain('class="datawrapper ');
+    expect(body).toContain('data-chromatic="ignore"');
     expect(body).toContain('data-external="1"');
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   registerPageview,
 } from './components/Analytics/Analytics.svelte';
 export { default as ArcCluster } from './components/ArcCluster/ArcCluster.svelte';
+export { default as ArcDatawrapperColumns } from './components/ArcCluster/ArcDatawrapperColumns.svelte';
 export { default as ArcHeader } from './components/ArcCluster/ArcHeader.svelte';
 export { default as ArcKicker } from './components/ArcCluster/ArcKicker.svelte';
 export { default as ArcFonts } from './components/ArcCluster/ArcFonts.svelte';


### PR DESCRIPTION
## Summary
- add ArcDatawrapperColumns as a reusable ArcCluster subcomponent for Reuters two-column Datawrapper embeds
- bundle the key .datawrapper iframe CSS contract and responsive two-column layout CSS
- bundle Datawrapper postMessage height syncing logic so charts resize correctly
- update ArcCluster Storybook example/docs to use the shared component
- export the new component from src/index.ts
- add focused tests for markup/CSS/message-listener contract

## Testing
- pnpm vitest run src/components/ArcCluster/ArcDatawrapperColumns.test.ts src/components/ArcCluster/ArcCluster.test.ts