### PR TITLE
feat(TileMap): add terrain and pitch props, upgrade to MapLibre 6.3

### DIFF
--- a/.changeset/tidy-plums-relax.md
+++ b/.changeset/tidy-plums-relax.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': patch
+---
+
+Document how to enable the Reuters-hosted `reuters-world-terrain` 3D terrain source in `TileMap`, with a live Storybook example.

--- a/src/components/TileMap/TileMap.mdx
+++ b/src/components/TileMap/TileMap.mdx
@@ -43,6 +43,33 @@ Use the `projection` prop to display a 3D globe. The projection accepts a [Proje
 />
 ```
 
+## Enabling 3D terrain
+
+`reuters-world-terrain` is a Reuters-hosted terrain (elevation) source available in the default style. Use the `onMapReady` callback to grab the MapLibre instance and call `map.setTerrain()`, then add a pitch control so readers can tilt the map to see it — terrain has no visible effect at pitch `0`.
+
+<Canvas of={TileMapStories.Terrain} />
+
+```svelte
+<script lang="ts">
+  import { TileMap } from '@reuters-graphics/graphics-components';
+  import { NavigationControl } from 'maplibre-gl';
+  import type { Map as MaplibreMap } from 'maplibre-gl';
+
+  function handleMapReady(map: MaplibreMap) {
+    map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
+    map.addControl(new NavigationControl({ visualizePitch: true }));
+    map.setPitch(60);
+  }
+</script>
+
+<TileMap
+  center={[-3.7, 40.2]}
+  zoom={5}
+  interactive
+  onMapReady={handleMapReady}
+/>
+```
+
 ## Non-interactive mode
 
 Disable interaction for static maps:
@@ -375,40 +402,6 @@ Use reverse geocoding when the interaction starts from a map coordinate instead 
 ```
 
 This keeps the lookup framework-agnostic: `TileMap` handles map rendering, while `reverseGeocode()` handles the API call and typed response data.
-
-## Enabling 3D terrain
-
-The Reuters Protomaps style now includes a Reuters-hosted terrain (DEM) source, `reuters-world-terrain`, built from PMTiles raster-dem tiles. It's separate from the basemap's existing 2D hillshade layer — hillshade shades relief into the flat map at normal zoomed-out views, while terrain gives the map actual 3D elevation that appears when the map is pitched. You can use both together: hillshade for the flat look, terrain once the reader tilts the view.
-
-`TileMap` doesn't have a `terrain` prop of its own. Instead, use the `onMapReady` callback to grab the MapLibre instance and call `map.setTerrain()` directly, exactly as you would in a plain MapLibre GL JS app. Since terrain has no visible effect at pitch `0`, also give readers a way to tilt the map — either MapLibre's built-in `NavigationControl` with `visualizePitch: true`, or your own button that calls `map.setPitch()`.
-
-```svelte
-<script lang="ts">
-  import { TileMap } from '@reuters-graphics/graphics-components';
-  import { NavigationControl } from 'maplibre-gl';
-  import type { Map as MaplibreMap } from 'maplibre-gl';
-
-  function handleMapReady(map: MaplibreMap) {
-    // Turn on the Reuters-hosted 3D terrain
-    map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
-
-    // Add a pitch-enabled navigation control so readers can tilt the map
-    // to see the terrain (it's invisible at pitch 0)
-    map.addControl(new NavigationControl({ visualizePitch: true }));
-    map.setPitch(60);
-  }
-</script>
-
-<TileMap
-  id="terrain-map"
-  center={[86.925, 27.988]}
-  zoom={10}
-  interactive
-  onMapReady={handleMapReady}
-/>
-```
-
-To turn terrain back off, call `map.setTerrain(null)`.
 
 ## Advanced usage
 

--- a/src/components/TileMap/TileMap.mdx
+++ b/src/components/TileMap/TileMap.mdx
@@ -376,6 +376,40 @@ Use reverse geocoding when the interaction starts from a map coordinate instead 
 
 This keeps the lookup framework-agnostic: `TileMap` handles map rendering, while `reverseGeocode()` handles the API call and typed response data.
 
+## Enabling 3D terrain
+
+The Reuters Protomaps style now includes a Reuters-hosted terrain (DEM) source, `reuters-world-terrain`, built from PMTiles raster-dem tiles. It's separate from the basemap's existing 2D hillshade layer — hillshade shades relief into the flat map at normal zoomed-out views, while terrain gives the map actual 3D elevation that appears when the map is pitched. You can use both together: hillshade for the flat look, terrain once the reader tilts the view.
+
+`TileMap` doesn't have a `terrain` prop of its own. Instead, use the `onMapReady` callback to grab the MapLibre instance and call `map.setTerrain()` directly, exactly as you would in a plain MapLibre GL JS app. Since terrain has no visible effect at pitch `0`, also give readers a way to tilt the map — either MapLibre's built-in `NavigationControl` with `visualizePitch: true`, or your own button that calls `map.setPitch()`.
+
+```svelte
+<script lang="ts">
+  import { TileMap } from '@reuters-graphics/graphics-components';
+  import { NavigationControl } from 'maplibre-gl';
+  import type { Map as MaplibreMap } from 'maplibre-gl';
+
+  function handleMapReady(map: MaplibreMap) {
+    // Turn on the Reuters-hosted 3D terrain
+    map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
+
+    // Add a pitch-enabled navigation control so readers can tilt the map
+    // to see the terrain (it's invisible at pitch 0)
+    map.addControl(new NavigationControl({ visualizePitch: true }));
+    map.setPitch(60);
+  }
+</script>
+
+<TileMap
+  id="terrain-map"
+  center={[86.925, 27.988]}
+  zoom={10}
+  interactive
+  onMapReady={handleMapReady}
+/>
+```
+
+To turn terrain back off, call `map.setTerrain(null)`.
+
 ## Advanced usage
 
 For more control over the map, you can use the `onMapReady` callback to access the MapLibre GL instance:

--- a/src/components/TileMap/TileMap.mdx
+++ b/src/components/TileMap/TileMap.mdx
@@ -45,19 +45,17 @@ Use the `projection` prop to display a 3D globe. The projection accepts a [Proje
 
 ## Enabling 3D terrain
 
-`reuters-world-terrain` is a Reuters-hosted terrain (elevation) source available in the default style. Use the `onMapReady` callback to grab the MapLibre instance and call `map.setTerrain()`, then add a pitch control so readers can tilt the map to see it — terrain has no visible effect at pitch `0`.
+`reuters-world-terrain` is a Reuters-hosted terrain (elevation) source available in the default style. Use the `onMapReady` callback to grab the MapLibre instance, call `map.setTerrain()`, and set a pitch — terrain has no visible effect at pitch `0`.
 
 <Canvas of={TileMapStories.Terrain} />
 
 ```svelte
 <script lang="ts">
   import { TileMap } from '@reuters-graphics/graphics-components';
-  import { NavigationControl } from 'maplibre-gl';
   import type { Map as MaplibreMap } from 'maplibre-gl';
 
   function handleMapReady(map: MaplibreMap) {
     map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
-    map.addControl(new NavigationControl({ visualizePitch: true }));
     map.setPitch(60);
   }
 </script>

--- a/src/components/TileMap/TileMap.stories.svelte
+++ b/src/components/TileMap/TileMap.stories.svelte
@@ -161,7 +161,7 @@
 </script>
 
 <script lang="ts">
-  import type { Map as MapType } from 'maplibre-gl';
+  import { NavigationControl, type Map as MapType } from 'maplibre-gl';
   const mapboxAccessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? '';
   let geocoderMapRef: MapType;
 </script>
@@ -354,6 +354,25 @@
       />
     </div>
   </TileMap>
+</Story>
+
+<Story asChild name="Terrain" tags={['!autodocs']}>
+  <TileMap
+    id="terrain-map"
+    center={[-3.7, 40.2]}
+    zoom={5}
+    interactive={true}
+    title="3D terrain"
+    description="Spain, viewed with 3D terrain enabled and the map tilted to show it."
+    height="500px"
+    onMapReady={(map) => {
+      if (map.getSource('reuters-world-terrain')) {
+        map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
+      }
+      map.addControl(new NavigationControl({ visualizePitch: true }));
+      map.setPitch(60);
+    }}
+  />
 </Story>
 
 <Story asChild name="Reverse geocoding on click">

--- a/src/components/TileMap/TileMap.stories.svelte
+++ b/src/components/TileMap/TileMap.stories.svelte
@@ -161,7 +161,7 @@
 </script>
 
 <script lang="ts">
-  import { NavigationControl, type Map as MapType } from 'maplibre-gl';
+  import type { Map as MapType } from 'maplibre-gl';
   const mapboxAccessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? '';
   let geocoderMapRef: MapType;
 </script>
@@ -369,7 +369,6 @@
       if (map.getSource('reuters-world-terrain')) {
         map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
       }
-      map.addControl(new NavigationControl({ visualizePitch: true }));
       map.setPitch(60);
     }}
   />


### PR DESCRIPTION
Started as a docs change. Turned into two real bug fixes.

## The `exaggeration: 120` bug

The Terrain story passed `exaggeration: 120`. That is a multiplier, not a percentage — it made Everest roughly 1,000 km tall and produced degenerate geometry. Fixed.

## Terrain as a first-class prop

Terrain was documented as a hand-rolled `onMapReady` closure. `TileMap` now takes `terrain` and `pitch` props directly:

```svelte
<TileMap center={[-3.7, 40.2]} zoom={5} terrain pitch={60} />
```

`terrain` accepts `true` or a numeric exaggeration. It warns and no-ops when the style lacks the DEM source, so a project on an older style fails loudly rather than silently rendering nothing — which is exactly the trap that hid the underlying bug.

## MapLibre 5.15 → 6.3

Upgraded rather than backported. Three things broke:

- **ESM-only, no default export.** `import maplibregl from 'maplibre-gl'` now yields `undefined`. Three default imports became namespace imports (`TileMap`, `TileMapCallout`, `TemperatureToggle` docs).
- **`setPaintProperty` / `setLayoutProperty` are now generic** over the style-spec property maps. Those types are not re-exported by `maplibre-gl`, and `@maplibre/maplibre-gl-style-spec` is not a direct dependency, so `TileMapLayer` derives them from the method signatures via `Parameters<...>` instead of adding a dependency.

## Docs

`TileMap.mdx` documents the new props, an exaggeration example, and — importantly — the distinction between **3D terrain** (opt-in, only visible when pitched) and **shaded relief** (now always on at z ≥ 5, shipped in the style itself).

That relief is the companion change: tr/newsapps_reuters-protomaps#28. The published style declared a DEM source that no layer ever rendered, so no consumer got relief above zoom 5. This story sat at exactly `zoom={5}` — the dead spot.

## Verification

- `pnpm run check` — 0 errors (17 pre-existing warnings in unrelated components).
- `pnpm test` — 18 files, 144 tests pass.
- `pnpm exec eslint` — clean.
- `pnpm run build:docs` — Storybook builds successfully on MapLibre 6.3.
