### PR TITLE
docs(TileMap): reorder Terrain story to match doc section order

### DIFF
--- a/src/components/TileMap/TileMap.stories.svelte
+++ b/src/components/TileMap/TileMap.stories.svelte
@@ -192,6 +192,24 @@
   }}
 />
 
+<Story asChild name="Terrain" tags={['!autodocs']}>
+  <TileMap
+    id="terrain-map"
+    center={[-3.7, 40.2]}
+    zoom={5}
+    interactive={true}
+    title="3D terrain"
+    description="Spain, viewed with 3D terrain enabled and the map tilted to show it."
+    height="500px"
+    onMapReady={(map) => {
+      if (map.getSource('reuters-world-terrain')) {
+        map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
+      }
+      map.setPitch(60);
+    }}
+  />
+</Story>
+
 <Story
   name="Non-interactive"
   tags={['!autodocs']}
@@ -354,24 +372,6 @@
       />
     </div>
   </TileMap>
-</Story>
-
-<Story asChild name="Terrain" tags={['!autodocs']}>
-  <TileMap
-    id="terrain-map"
-    center={[-3.7, 40.2]}
-    zoom={5}
-    interactive={true}
-    title="3D terrain"
-    description="Spain, viewed with 3D terrain enabled and the map tilted to show it."
-    height="500px"
-    onMapReady={(map) => {
-      if (map.getSource('reuters-world-terrain')) {
-        map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
-      }
-      map.setPitch(60);
-    }}
-  />
 </Story>
 
 <Story asChild name="Reverse geocoding on click">


### PR DESCRIPTION
## Summary

Follow-up to #492: reorders the "Terrain" story in `TileMap.stories.svelte` so it appears right after "Globe view" (before "Non-interactive") in the Storybook sidebar - matching the order of the "Enabling 3D terrain" section in `TileMap.mdx`.

## Verification

- Verified visually in Storybook that the sidebar order now matches the docs order.
- Lint clean.
- `pnpm run build:docs` passes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
