### PR TITLE
feat(TileMap): add terrain and pitch props, upgrade to MapLibre 6.3

### DIFF
--- a/.changeset/olive-moons-tickle.md
+++ b/.changeset/olive-moons-tickle.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-components': minor
+---
+
+Add `terrain` and `pitch` props to `TileMap` and upgrade `maplibre-gl` to 6.3.

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "dayjs": "^1.11.13",
     "es-toolkit": "^1.35.0",
     "journalize": "^2.6.0",
-    "maplibre-gl": "^5.15.0",
+    "maplibre-gl": "^6.3.0",
     "mp4box": "^0.5.4",
     "pmtiles": "^4.3.2",
     "proper-url-join": "^2.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0
       maplibre-gl:
-        specifier: ^5.15.0
-        version: 5.15.0
+        specifier: ^6.3.0
+        version: 6.3.0
       mp4box:
         specifier: ^0.5.4
         version: 0.5.4
@@ -224,7 +224,7 @@ importers:
         version: 5.56.4(@typescript-eslint/types@8.62.1)
       svelte-check:
         specifier: ^4.7.1
-        version: 4.7.1(picomatch@4.0.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@5.8.3)
+        version: 4.7.1(picomatch@4.0.5)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@5.8.3)
       ts-morph:
         specifier: ^28.0.0
         version: 28.0.0
@@ -612,39 +612,34 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mapbox/geojson-rewind@0.5.2':
-    resolution: {integrity: sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==}
-    hasBin: true
-
-  '@mapbox/jsonlint-lines-primitives@2.0.2':
-    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
-    engines: {node: '>= 0.6'}
+  '@mapbox/jsonlint-lines-primitives@2.0.3':
+    resolution: {integrity: sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==}
+    engines: {node: '>= 22'}
 
   '@mapbox/point-geometry@1.1.0':
     resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
 
-  '@mapbox/tiny-sdf@2.0.7':
-    resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
 
-  '@mapbox/unitbezier@0.0.1':
-    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
 
-  '@mapbox/vector-tile@2.0.4':
-    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+  '@mapbox/vector-tile@3.0.0':
+    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
 
-  '@mapbox/whoots-js@3.1.0':
-    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
-    engines: {node: '>=6.0.0'}
+  '@maplibre/geojson-vt@6.1.1':
+    resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
 
-  '@maplibre/maplibre-gl-style-spec@24.4.1':
-    resolution: {integrity: sha512-UKhA4qv1h30XT768ccSv5NjNCX+dgfoq2qlLVmKejspPcSQTYD4SrVucgqegmYcKcmwf06wcNAa/kRd0NHWbUg==}
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
     hasBin: true
 
-  '@maplibre/mlt@1.1.2':
-    resolution: {integrity: sha512-SQKdJ909VGROkA6ovJgtHNs9YXV4YXUPS+VaZ50I2Mt951SLlUm2Cv34x5Xwc1HiFlsd3h2Yrs5cn7xzqBmENw==}
+  '@maplibre/mlt@1.1.12':
+    resolution: {integrity: sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==}
 
-  '@maplibre/vt-pbf@4.2.0':
-    resolution: {integrity: sha512-bxrk/kQUwWXZgmqYgwOCnZCMONCRi3MJMqJdza4T3E4AeR5i+VyMnaJ8iDWtWxdfEAJRtrzIOeJtxZSy5mFrFA==}
+  '@maplibre/vt-pbf@4.3.2':
+    resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
 
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
@@ -1423,9 +1418,6 @@ packages:
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
-  '@types/geojson-vt@3.2.5':
-    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
-
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -1494,9 +1486,6 @@ packages:
 
   '@types/react@18.3.20':
     resolution: {integrity: sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==}
-
-  '@types/supercluster@7.1.3':
-    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/supports-color@8.1.3':
     resolution: {integrity: sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==}
@@ -2276,8 +2265,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  earcut@3.0.2:
-    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2619,9 +2608,6 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  geojson-vt@4.0.2:
-    resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2629,10 +2615,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -3014,8 +2996,8 @@ packages:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
 
-  kdbush@4.0.2:
-    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3183,8 +3165,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  maplibre-gl@5.15.0:
-    resolution: {integrity: sha512-pPeu/t4yPDX/+Uf9ibLUdmaKbNMlGxMAX+tBednYukol2qNk2TZXAlhdohWxjVvTO3is8crrUYv3Ok02oAaKzA==}
+  maplibre-gl@6.3.0:
+    resolution: {integrity: sha512-F0Is48MTzn3DvOEidPjh68E0kuSA7hdzY1YIR0ypPtFgcif3WPtzI1oZFgsv9WtHmarQnbwIXfsf+EfQYvM00A==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   marked-smartypants@1.1.9:
@@ -3642,8 +3624,8 @@ packages:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
 
-  pbf@4.0.1:
-    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+  pbf@5.1.2:
+    resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
     hasBin: true
 
   picocolors@1.1.1:
@@ -4181,9 +4163,6 @@ packages:
 
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
-
-  supercluster@8.0.1:
-    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -5080,50 +5059,42 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mapbox/geojson-rewind@0.5.2':
-    dependencies:
-      get-stream: 6.0.1
-      minimist: 1.2.8
-
-  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+  '@mapbox/jsonlint-lines-primitives@2.0.3': {}
 
   '@mapbox/point-geometry@1.1.0': {}
 
-  '@mapbox/tiny-sdf@2.0.7': {}
+  '@mapbox/tiny-sdf@2.2.0': {}
 
-  '@mapbox/unitbezier@0.0.1': {}
+  '@mapbox/unitbezier@1.0.0': {}
 
-  '@mapbox/vector-tile@2.0.4':
+  '@mapbox/vector-tile@3.0.0':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
-      pbf: 4.0.1
+      pbf: 5.1.2
 
-  '@mapbox/whoots-js@3.1.0': {}
-
-  '@maplibre/maplibre-gl-style-spec@24.4.1':
+  '@maplibre/geojson-vt@6.1.1':
     dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
-      '@mapbox/unitbezier': 0.0.1
+      kdbush: 4.1.0
+
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/unitbezier': 1.0.0
       json-stringify-pretty-compact: 4.0.0
       minimist: 1.2.8
       quickselect: 3.0.0
-      rw: 1.3.3
       tinyqueue: 3.0.0
 
-  '@maplibre/mlt@1.1.2':
+  '@maplibre/mlt@1.1.12':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
 
-  '@maplibre/vt-pbf@4.2.0':
+  '@maplibre/vt-pbf@4.3.2':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
-      '@mapbox/vector-tile': 2.0.4
-      '@types/geojson-vt': 3.2.5
-      '@types/supercluster': 7.1.3
-      geojson-vt: 4.0.2
-      pbf: 4.0.1
-      supercluster: 8.0.1
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
 
   '@mdx-js/react@3.1.0(@types/react@18.3.20)(react@18.3.1)':
     dependencies:
@@ -5799,10 +5770,6 @@ snapshots:
       '@types/jsonfile': 6.1.4
       '@types/node': 22.14.1
 
-  '@types/geojson-vt@3.2.5':
-    dependencies:
-      '@types/geojson': 7946.0.16
-
   '@types/geojson@7946.0.16': {}
 
   '@types/google-publisher-tag@1.20250210.0': {}
@@ -5875,10 +5842,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.14
       csstype: 3.1.3
-
-  '@types/supercluster@7.1.3':
-    dependencies:
-      '@types/geojson': 7946.0.16
 
   '@types/supports-color@8.1.3': {}
 
@@ -6672,7 +6635,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  earcut@3.0.2: {}
+  earcut@3.2.3: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -7084,10 +7047,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
-  fdir@6.5.0(picomatch@4.0.2):
-    optionalDependencies:
-      picomatch: 4.0.2
-
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -7167,8 +7126,6 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geojson-vt@4.0.2: {}
-
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -7186,8 +7143,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  get-stream@6.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -7556,7 +7511,7 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
-  kdbush@4.0.2: {}
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -7701,30 +7656,24 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  maplibre-gl@5.15.0:
+  maplibre-gl@6.3.0:
     dependencies:
-      '@mapbox/geojson-rewind': 0.5.2
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
       '@mapbox/point-geometry': 1.1.0
-      '@mapbox/tiny-sdf': 2.0.7
-      '@mapbox/unitbezier': 0.0.1
-      '@mapbox/vector-tile': 2.0.4
-      '@mapbox/whoots-js': 3.1.0
-      '@maplibre/maplibre-gl-style-spec': 24.4.1
-      '@maplibre/mlt': 1.1.2
-      '@maplibre/vt-pbf': 4.2.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 1.0.0
+      '@mapbox/vector-tile': 3.0.0
+      '@maplibre/geojson-vt': 6.1.1
+      '@maplibre/maplibre-gl-style-spec': 26.2.1
+      '@maplibre/mlt': 1.1.12
+      '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
-      '@types/geojson-vt': 3.2.5
-      '@types/supercluster': 7.1.3
-      earcut: 3.0.2
-      geojson-vt: 4.0.2
+      earcut: 3.2.3
       gl-matrix: 3.4.4
-      kdbush: 4.0.2
+      kdbush: 4.1.0
       murmurhash-js: 1.0.0
-      pbf: 4.0.1
+      pbf: 5.1.2
       potpack: 2.1.0
       quickselect: 3.0.0
-      supercluster: 8.0.1
       tinyqueue: 3.0.0
 
   marked-smartypants@1.1.9(marked@15.0.8):
@@ -8502,7 +8451,7 @@ snapshots:
 
   pathval@2.0.0: {}
 
-  pbf@4.0.1:
+  pbf@5.1.2:
     dependencies:
       resolve-protobuf-schema: 2.1.0
 
@@ -9117,10 +9066,6 @@ snapshots:
 
   stylis@4.3.6: {}
 
-  supercluster@8.0.1:
-    dependencies:
-      kdbush: 4.0.2
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -9135,12 +9080,12 @@ snapshots:
       svelte: 5.56.4(@typescript-eslint/types@8.62.1)
       zimmerframe: 1.1.2
 
-  svelte-check@4.7.1(picomatch@4.0.2)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@5.8.3):
+  svelte-check@4.7.1(picomatch@4.0.5)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@5.8.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       '@sveltejs/load-config': 0.2.0
       chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.2)
+      fdir: 6.5.0(picomatch@4.0.5)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.56.4(@typescript-eslint/types@8.62.1)

--- a/src/components/Temperature/TemperatureToggle.mdx
+++ b/src/components/Temperature/TemperatureToggle.mdx
@@ -66,7 +66,7 @@ the same synchronous task before the rest of the UI reflects the new unit, use
 <script lang="ts">
   import { TemperatureToggle } from '@reuters-graphics/graphics-components';
   import type { TemperatureUnit } from '@reuters-graphics/graphics-components';
-  import maplibregl from 'maplibre-gl';
+  import * as maplibregl from 'maplibre-gl';
 
   let map: maplibregl.Map;
 </script>

--- a/src/components/TileMap/TileMap.mdx
+++ b/src/components/TileMap/TileMap.mdx
@@ -45,28 +45,25 @@ Use the `projection` prop to display a 3D globe. The projection accepts a [Proje
 
 ## Enabling 3D terrain
 
-`reuters-world-terrain` is a Reuters-hosted terrain (elevation) source available in the default style. Use the `onMapReady` callback to grab the MapLibre instance, call `map.setTerrain()`, and set a pitch — terrain has no visible effect at pitch `0`.
+The default style publishes Reuters-hosted elevation tiles. Set `terrain` to switch them on, and `pitch` to tilt the map — terrain has no visible effect at pitch `0`.
 
 <Canvas of={TileMapStories.Terrain} />
 
 ```svelte
 <script lang="ts">
   import { TileMap } from '@reuters-graphics/graphics-components';
-  import type { Map as MaplibreMap } from 'maplibre-gl';
-
-  function handleMapReady(map: MaplibreMap) {
-    map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
-    map.setPitch(60);
-  }
 </script>
 
-<TileMap
-  center={[-3.7, 40.2]}
-  zoom={5}
-  interactive
-  onMapReady={handleMapReady}
-/>
+<TileMap center={[-3.7, 40.2]} zoom={5} interactive terrain pitch={60} />
 ```
+
+Pass a number to set your own exaggeration. `1` is true-to-life; higher values are an editorial choice, and anything much above `2` looks like a caricature.
+
+```svelte
+<TileMap center={[-3.7, 40.2]} zoom={5} terrain={2} pitch={60} />
+```
+
+Terrain is 3D geometry, so it only shows on a tilted map. Shaded relief is separate: it ships in the style as a flat hillshade and is already drawn on every map at zoom 5 and above, whether or not `terrain` is on.
 
 ## Non-interactive mode
 
@@ -438,6 +435,8 @@ For more control over the map, you can use the `onMapReady` callback to access t
 - **zoom**: `number` - Initial zoom level (default: `2`)
 - **minZoom**: `number` - Minimum zoom level (default: `0`)
 - **maxZoom**: `number` - Maximum zoom level (default: `22`)
+- **terrain**: `boolean | number` - Show 3D terrain from the style's elevation tiles. `true` uses the default exaggeration of `1.5`; pass a number to set your own (default: `false`). Needs a non-zero `pitch` to be visible.
+- **pitch**: `number` - Tilt the map, in degrees away from straight down, capped at `60` (default: `0`)
 - **interactive**: `boolean` - Enable interactive controls (default: `true`)
 - **styleUrl**: `string` - Map style URL (default: Reuters Protomaps style)
 - **emphasizeLabels**: `boolean` - Darken the basemap's place labels and add a white halo so city/region names stay readable over colored data layers (default: `false`). Applied on map load; a no-op on styles without `place` labels.

--- a/src/components/TileMap/TileMap.stories.svelte
+++ b/src/components/TileMap/TileMap.stories.svelte
@@ -201,12 +201,8 @@
     title="3D terrain"
     description="Spain, viewed with 3D terrain enabled and the map tilted to show it."
     height="500px"
-    onMapReady={(map) => {
-      if (map.getSource('reuters-world-terrain')) {
-        map.setTerrain({ source: 'reuters-world-terrain', exaggeration: 1.2 });
-      }
-      map.setPitch(60);
-    }}
+    terrain
+    pitch={60}
   />
 </Story>
 

--- a/src/components/TileMap/TileMap.svelte
+++ b/src/components/TileMap/TileMap.svelte
@@ -5,7 +5,7 @@
 -->
 <script lang="ts" module>
   import { Protocol } from 'pmtiles';
-  import maplibregl from 'maplibre-gl';
+  import * as maplibregl from 'maplibre-gl';
 
   // Track if PMTiles protocol has been registered (only do this once per page)
   let pmtilesProtocolRegistered = false;
@@ -16,6 +16,24 @@
       maplibregl.addProtocol('pmtiles', protocol.tile);
       pmtilesProtocolRegistered = true;
     }
+  }
+
+  /** Elevation source published by the Reuters basemap style. */
+  const TERRAIN_SOURCE_ID = 'reuters-world-terrain';
+  const DEFAULT_TERRAIN_EXAGGERATION = 1.5;
+
+  function applyTerrain(map: maplibregl.Map, terrain: boolean | number) {
+    if (!map.getSource(TERRAIN_SOURCE_ID)) {
+      console.warn(
+        `TileMap: terrain is on but the style has no "${TERRAIN_SOURCE_ID}" source, so no terrain was applied.`
+      );
+      return;
+    }
+    map.setTerrain({
+      source: TERRAIN_SOURCE_ID,
+      exaggeration:
+        terrain === true ? DEFAULT_TERRAIN_EXAGGERATION : Number(terrain),
+    });
   }
 </script>
 
@@ -62,6 +80,18 @@
      * See https://maplibre.org/maplibre-style-spec/types/#projectiondefinition
      */
     projection?: ProjectionSpecification;
+    /**
+     * Show 3D terrain using the basemap's elevation tiles. Pass `true` for the
+     * default exaggeration or a number to set your own. Terrain is only visible
+     * on a tilted map, so pair it with `pitch`. A no-op on styles without an
+     * elevation source, so it degrades gracefully.
+     */
+    terrain?: boolean | number;
+    /**
+     * Tilt the map, in degrees away from straight down. Required to see
+     * `terrain`. MapLibre caps this at 60.
+     */
+    pitch?: number;
     /**
      * Enable interactive controls (zoom, pan, etc.)
      */
@@ -111,6 +141,8 @@
     minZoom = 0,
     maxZoom = 22,
     projection,
+    terrain = false,
+    pitch = 0,
     interactive = true,
     styleUrl = 'https://graphics.thomsonreuters.com/reuters-protomaps/style.json',
     emphasizeLabels = false,
@@ -144,6 +176,7 @@
         zoom,
         minZoom,
         maxZoom,
+        pitch,
         attributionControl: false,
         scrollZoom: false, // Always disabled for consistency
         doubleClickZoom: interactive,
@@ -197,6 +230,10 @@
         // Set projection after map loads if specified
         if (projection) {
           map.setProjection(projection);
+        }
+
+        if (terrain) {
+          applyTerrain(map, terrain);
         }
 
         if (onMapReady) {

--- a/src/components/TileMap/TileMapLayer.svelte
+++ b/src/components/TileMap/TileMapLayer.svelte
@@ -6,6 +6,11 @@
   import type { GeoJSON } from 'geojson';
   import { findFirstSymbolLayerId } from './labels';
 
+  type PaintProperty = Parameters<MaplibreMap['setPaintProperty']>[1];
+  type PaintValue = Parameters<MaplibreMap['setPaintProperty']>[2];
+  type LayoutProperty = Parameters<MaplibreMap['setLayoutProperty']>[1];
+  type LayoutValue = Parameters<MaplibreMap['setLayoutProperty']>[2];
+
   interface Props {
     /**
      * Unique ID for this layer
@@ -191,8 +196,10 @@
     const map = $mapStore;
     if (!map || !isInitialized || !paint) return;
 
+    // Object.entries widens keys to string, so each name is asserted back into
+    // the property union MapLibre expects.
     Object.entries(paint).forEach(([property, value]) => {
-      map.setPaintProperty(id, property, value);
+      map.setPaintProperty(id, property as PaintProperty, value as PaintValue);
     });
   });
 
@@ -202,7 +209,11 @@
     if (!map || !isInitialized || !layout) return;
 
     Object.entries(layout).forEach(([property, value]) => {
-      map.setLayoutProperty(id, property, value);
+      map.setLayoutProperty(
+        id,
+        property as LayoutProperty,
+        value as LayoutValue
+      );
     });
   });
 

--- a/src/components/TileMapCallout/TileMapCallout.svelte
+++ b/src/components/TileMapCallout/TileMapCallout.svelte
@@ -131,7 +131,7 @@ placement and lifecycle through the map context.
 </script>
 
 <script lang="ts">
-  import maplibregl from 'maplibre-gl';
+  import * as maplibregl from 'maplibre-gl';
   import { getContext, onDestroy, type Snippet } from 'svelte';
   import type { Map as MaplibreMap, Marker } from 'maplibre-gl';
   import type { Writable } from 'svelte/store';


### PR DESCRIPTION
Follow-up to #492, which landed the terrain docs. This lands the actual component work — it was written against that branch but got stranded when #492 merged first, so it never reached `main`.

## `terrain` and `pitch` props

Terrain was a hand-rolled `onMapReady` closure. `TileMap` now takes it directly:

```svelte
<TileMap center={[-3.7, 40.2]} zoom={5} terrain pitch={60} />
```

`terrain` accepts `true` or a numeric exaggeration. It warns and no-ops when the style lacks the DEM source, so a project pinned to an older style fails loudly instead of silently rendering nothing — which is exactly what made the original bug so hard to see.

## maplibre-gl 5.15 → 6.3

Upgraded rather than backported. Three things broke:

- **ESM-only, no default export.** `import maplibregl from 'maplibre-gl'` now yields `undefined`. Three default imports became namespace imports (`TileMap`, `TileMapCallout`, `TemperatureToggle` docs).
- **`setPaintProperty` / `setLayoutProperty` are now generic** over the style-spec property maps. Those types aren't re-exported by `maplibre-gl`, and `@maplibre/maplibre-gl-style-spec` isn't a direct dependency, so `TileMapLayer` derives them from the method signatures via `Parameters<…>` rather than taking on a new dependency.

## Context: the relief is now live

The published Reuters style declared a `reuters-world-terrain` DEM source but **no layer ever rendered it**, so no consumer got relief above zoom 5 — and this story sits at exactly `zoom={5}`. Fixed in tr/newsapps_reuters-protomaps#28 and promoted to production, which took the style from 65 to 66 layers.

So the docs now distinguish two separate things: **3D terrain** (opt-in, only visible when pitched) and **shaded relief** (flat, always on at z ≥ 5, shipped in the style itself).

## Verification

- `pnpm run check` — 0 errors (17 pre-existing warnings in unrelated components)
- `pnpm test` — 18 files, 144 tests pass
- `pnpm exec eslint` — clean
- `pnpm run build` — publint "All good!"
- `pnpm run build:docs` — Storybook builds on MapLibre 6.3

Expect a Chromatic diff on the Terrain story: it should now show real relief where it previously showed a flat map.
